### PR TITLE
logging: add syslog option

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -2,3 +2,4 @@ pgmoneta-mcp was created by the following authors:
 
 Haoran Zhang <andrewzhr9911@gmail.com>
 Jesper Pedersen <jesperpedersen.db@gmail.com>
+Ahmed Kamal <ahmedkamal200427@gmail.com>

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1269,7 +1269,7 @@ dependencies = [
 
 [[package]]
 name = "pgmoneta-mcp"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -1288,6 +1288,7 @@ dependencies = [
  "serde",
  "serde_ini",
  "serde_json",
+ "syslog-tracing",
  "tokio",
  "tracing",
  "tracing-appender",
@@ -1944,6 +1945,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syslog-tracing"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d349bc2df408b4bf656709a29643641cef7f1795d708f88b105c626a8f64f6e4"
+dependencies = [
+ "libc",
+ "tracing-core",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2155,9 +2167,9 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
-version = "0.1.41"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "log",
  "pin-project-lite",
@@ -2179,9 +2191,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.30"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2190,9 +2202,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.34"
+version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
  "valuable",
@@ -2211,9 +2223,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.20"
+version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2054a14f5307d601f88daf0553e1cbf472acc4f2c51afab632431cdcd72124d5"
+checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
 dependencies = [
  "chrono",
  "matchers",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,4 +51,5 @@ chrono = "0.4.42"
 rpassword = "7.4.0"
 serde_ini = "0.2.0"
 tracing-appender = "0.2.4"
+syslog-tracing = "0.3.1"
 

--- a/src/constant.rs
+++ b/src/constant.rs
@@ -502,4 +502,5 @@ impl LogLevel {
 impl LogType {
     pub const CONSOLE: &str = "console";
     pub const FILE: &str = "file";
+    pub const SYSLOG: &str = "syslog";
 }

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -14,6 +14,7 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 use super::constant::{LogLevel, LogType};
+use syslog_tracing::Syslog;
 use tracing::level_filters::LevelFilter;
 use tracing_appender::non_blocking::WorkerGuard;
 use tracing_appender::rolling;
@@ -71,6 +72,12 @@ impl Logger {
                 let file_appender = rolling::never(".", log_path);
                 let (writer, _guard) = tracing_appender::non_blocking(file_appender);
                 (BoxMakeWriter::new(writer), Some(_guard))
+            }
+            LogType::SYSLOG => {
+                let identity = c"pgmoneta-mcp";
+                let (options, facility) = Default::default();
+                let syslog = Syslog::new(identity, options, facility).unwrap();
+                (BoxMakeWriter::new(syslog), None)
             }
             _ => (BoxMakeWriter::new(std::io::stderr), None),
         }


### PR DESCRIPTION
This PR utilizes this crate `syslog_tracing` to extend logging types to include logging to syslog daemon
I have done a research about the available options, and found that the chosen crate is the best to use syslog along with doing the minimal changes.

Fixes: #16 

Ref:

- https://docs.rs/syslog-tracing/latest/syslog_tracing/index.html (The used crate)
- https://github.com/max-heller/tracing-syslog (it's repo)

- https://github.com/sp1ff/syslog-tracing?tab=readme-ov-file (Unused crate)



Tests:

```
sudo tail -f /var/log/syslog | grep "pgmoneta-mcp" 
2026-01-25T13:27:17.132325+02:00 ahmed-kamal-Legion-5-15ACH6 pgmoneta-mcp: 2026-01-25 11:27:17  INFO pgmoneta_mcp_server: 79: Starting MCP server at 0.0.0.0:6432
2026-01-25T13:28:58.048059+02:00 ahmed-kamal-Legion-5-15ACH6 pgmoneta-mcp: 2026-01-25 11:28:58  INFO pgmoneta_mcp_server: 79: Starting MCP server at 0.0.0.0:6432
2026-01-25T13:30:00.390363+02:00 ahmed-kamal-Legion-5-15ACH6 pgmoneta-mcp: 2026-01-25 11:30:00  INFO pgmoneta_mcp::handler: 219: initialize from http server initialize_headers={"host": "0.0.0.0:6432", "user-agent": "curl/8.5.0", "content-type": "application/json", "accept": "application/json, text/event-stream", "content-length": "242"} initialize_uri=/v1


```