### PR TITLE
logging: support log file truncation upon server start

### DIFF
--- a/doc/CONFIGURATION.md
+++ b/doc/CONFIGURATION.md
@@ -17,6 +17,7 @@ The other section, called `[pgmoneta]`, is where you configure connection with `
 | log_type | console | String | No | The logging type (console, file, syslog) |
 | log_level | info | String | No | The logging level, any of the strings `trace`, `debug`, `info`, `warn` and `error`|
 | log_path | pgmoneta_mcp.log | String | No | The log file location |
+| log_mode | append | String | No | Append to or create the log file, any of the strings (`append`, `create`) |
 
 ## [pgmoneta]
 

--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -57,6 +57,7 @@ async fn main() -> anyhow::Result<()> {
         config.pgmoneta_mcp.log_type.as_str(),
         config.pgmoneta_mcp.log_line_prefix.as_str(),
         config.pgmoneta_mcp.log_path.as_str(),
+        config.pgmoneta_mcp.log_mode.as_str(),
     );
 
     let handler = StreamableHttpService::new(

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -48,6 +48,8 @@ pub struct PgmonetaMcpConfiguration {
     pub log_type: String,
     #[serde(default = "default_log_line_prefix")]
     pub log_line_prefix: String,
+    #[serde(default = "default_log_mode")]
+    pub log_mode: String,
 }
 
 pub fn load_configuration(config_path: &str, user_path: &str) -> anyhow::Result<Configuration> {
@@ -96,4 +98,8 @@ fn default_log_type() -> String {
 
 fn default_log_line_prefix() -> String {
     "%Y-%m-%d %H:%M:%S".to_string()
+}
+
+fn default_log_mode() -> String {
+    "append".to_string()
 }

--- a/src/constant.rs
+++ b/src/constant.rs
@@ -31,6 +31,7 @@ pub struct Sort;
 pub struct LogLevel;
 
 pub struct LogType;
+pub struct LogMode;
 
 impl Command {
     pub const LIST_BACKUP: u32 = 2;
@@ -503,4 +504,9 @@ impl LogType {
     pub const CONSOLE: &str = "console";
     pub const FILE: &str = "file";
     pub const SYSLOG: &str = "syslog";
+}
+
+impl LogMode {
+    pub const APPEND: &str = "append";
+    pub const CREATE: &str = "create";
 }


### PR DESCRIPTION
This PR adds new configuration option `log_mode` with two choices `create` and `append` (default), this defines the policy of whether the server always creates a new log file or can append to an existing log file if already exists.

##### Proposal 
This change made me think about if we need to have a `LogConfig` struct that is encapsulating all the config of the logger/logging, I believe this makes extending and adding more logging config more easy, and functions definitions more shorter.

#### Usage
`log_mode = create`
`log_mode = append`

#### Testing
Verified locally.

error shape on failure of a opening the log file
```
thread 'main' (103700) panicked at src/logging.rs:85:45:
Failed to open log file: /var/log/pgmoneta/pgmoneta.log
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```
#### Issue 
Fixes: #18 
