### PR TITLE
[#19] Add RPM infrastructure

### DIFF
--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -1,0 +1,39 @@
+name: RPM Build
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build-rpm:
+    runs-on: ubuntu-latest
+    container: fedora:latest
+    steps:
+      - name: Install git
+        run: dnf install -y git
+
+      - uses: actions/checkout@v4
+
+      - name: Install build dependencies
+        run: dnf install -y rust cargo rpm-build systemd-rpm-macros
+
+      - name: Build RPM
+        run: |
+          VERSION=$(grep '^version =' Cargo.toml | head -n 1 | cut -d '"' -f 2)
+          echo "Building version $VERSION"
+          sed -i "s/^Version:.*/Version:        $VERSION/" contrib/rpm/pgmoneta-mcp.spec
+          mkdir -p rpmbuild/{BUILD,RPMS,SOURCES,SPECS,SRPMS}
+          tar --exclude=rpmbuild --transform "s|^|pgmoneta-mcp-$VERSION/|" -czf rpmbuild/SOURCES/v$VERSION.tar.gz .
+          rpmbuild --define "_topdir $(pwd)/rpmbuild" \
+            --define "_unitdir /usr/lib/systemd/system" \
+            --define "_bindir /usr/bin" \
+            --define "_sysconfdir /etc" \
+            -bb contrib/rpm/pgmoneta-mcp.spec
+
+      - name: Archive RPM
+        uses: actions/upload-artifact@v4
+        with:
+          name: pgmoneta-mcp-rpm
+          path: rpmbuild/RPMS/x86_64/*.rpm

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .idea/
 **/master.key
 **/default.profraw
+rpmbuild/

--- a/AUTHORS
+++ b/AUTHORS
@@ -4,3 +4,4 @@ Haoran Zhang <andrewzhr9911@gmail.com>
 Jesper Pedersen <jesperpedersen.db@gmail.com>
 Ahmed Kamal <ahmedkamal200427@gmail.com>
 Induwara Gunasena <induwaragunasena.sl@gmail.com>
+Noor Amjad <xdjust18@gmail.com>

--- a/contrib/rpm/pgmoneta-mcp-users.conf
+++ b/contrib/rpm/pgmoneta-mcp-users.conf
@@ -1,0 +1,2 @@
+# pgmoneta-mcp users configuration
+# Use pgmoneta-mcp-admin to manage users

--- a/contrib/rpm/pgmoneta-mcp.conf
+++ b/contrib/rpm/pgmoneta-mcp.conf
@@ -1,0 +1,10 @@
+[pgmoneta_mcp]
+port = 8000
+log_type = file
+log_level = info
+log_path = /var/log/pgmoneta-mcp/pgmoneta-mcp.log
+log_mode = append
+
+[pgmoneta]
+host = localhost
+port = 5000

--- a/contrib/rpm/pgmoneta-mcp.service
+++ b/contrib/rpm/pgmoneta-mcp.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=pgmoneta MCP server
+After=network.target
+
+[Service]
+Type=simple
+User=pgmoneta
+Group=pgmoneta
+ExecStart=/usr/bin/pgmoneta-mcp-server -c /etc/pgmoneta-mcp/pgmoneta-mcp.conf -u /etc/pgmoneta-mcp/pgmoneta-mcp-users.conf
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target

--- a/contrib/rpm/pgmoneta-mcp.spec
+++ b/contrib/rpm/pgmoneta-mcp.spec
@@ -1,0 +1,66 @@
+Name:           pgmoneta-mcp
+Version:        0.2.0
+Release:        1%{?dist}
+Summary:        MCP server for pgmoneta
+License:        GPLv3+
+URL:            https://github.com/pgmoneta/pgmoneta_mcp
+Source0:        https://github.com/pgmoneta/pgmoneta_mcp/archive/v%{version}.tar.gz
+
+BuildRequires:  rust
+BuildRequires:  cargo
+BuildRequires:  systemd-rpm-macros
+
+Requires:       systemd
+Requires(pre):  shadow-utils
+Provides:       group(pgmoneta)
+Provides:       user(pgmoneta)
+
+%description
+pgmoneta MCP is the official pgmoneta MCP server built for pgmoneta,
+a backup / restore solution for PostgreSQL.
+
+%prep
+%setup -q
+
+%build
+cargo build --release
+
+%install
+rm -rf %{buildroot}
+install -D -m 0755 target/release/pgmoneta-mcp-server %{buildroot}%{_bindir}/pgmoneta-mcp-server
+install -D -m 0755 target/release/pgmoneta-mcp-admin %{buildroot}%{_bindir}/pgmoneta-mcp-admin
+install -D -m 0644 contrib/rpm/pgmoneta-mcp.conf %{buildroot}%{_sysconfdir}/pgmoneta-mcp/pgmoneta-mcp.conf
+install -D -m 0644 contrib/rpm/pgmoneta-mcp-users.conf %{buildroot}%{_sysconfdir}/pgmoneta-mcp/pgmoneta-mcp-users.conf
+install -D -m 0644 contrib/rpm/pgmoneta-mcp.service %{buildroot}%{_unitdir}/pgmoneta-mcp.service
+install -d -m 0755 %{buildroot}/var/log/pgmoneta-mcp
+
+%pre
+getent group pgmoneta >/dev/null || groupadd -r pgmoneta
+getent passwd pgmoneta >/dev/null || \
+    useradd -r -g pgmoneta -d /home/pgmoneta -s /sbin/nologin \
+    -c "pgmoneta user" pgmoneta
+exit 0
+
+%post
+%systemd_post pgmoneta-mcp.service
+
+%preun
+%systemd_preun pgmoneta-mcp.service
+
+%postun
+%systemd_postun_with_restart pgmoneta-mcp.service
+
+%files
+%license LICENSE
+%doc README.md
+%{_bindir}/pgmoneta-mcp-server
+%{_bindir}/pgmoneta-mcp-admin
+%dir %{_sysconfdir}/pgmoneta-mcp
+%config(noreplace) %attr(0640, pgmoneta, pgmoneta) %{_sysconfdir}/pgmoneta-mcp/pgmoneta-mcp.conf
+%config(noreplace) %attr(0640, pgmoneta, pgmoneta) %{_sysconfdir}/pgmoneta-mcp/pgmoneta-mcp-users.conf
+%{_unitdir}/pgmoneta-mcp.service
+%dir %attr(0750, pgmoneta, pgmoneta) /var/log/pgmoneta-mcp
+
+%changelog
+* Sat Feb 08 2025 pgmoneta-mcp developers <pgmoneta-mcp@pgmoneta.org> - 0.2.0-1
+- Initial release

--- a/doc/RPM.md
+++ b/doc/RPM.md
@@ -1,0 +1,210 @@
+# RPM
+
+This document describes how to build, install, configure and use the RPM package for pgmoneta-mcp.
+
+The RPM packaging files are located in `contrib/rpm/`.
+
+## Prerequisites
+
+You need the following packages installed to build the RPM:
+
+* `rust`
+* `cargo`
+* `rpm-build`
+* `systemd-rpm-macros`
+
+On Fedora / RHEL / CentOS:
+
+```
+sudo dnf install rust cargo rpm-build systemd-rpm-macros
+```
+
+On Ubuntu / Debian:
+
+```
+sudo apt install rustc cargo rpm systemd
+```
+
+On Arch Linux:
+
+```
+sudo pacman -S rust cargo rpm-tools systemd
+```
+
+## Building
+
+1. Prepare the build environment:
+   ```
+   mkdir -p rpmbuild/{BUILD,RPMS,SOURCES,SPECS,SRPMS}
+   ```
+
+2. Update the version in the spec file and create the source tarball:
+   ```
+   VERSION=$(grep '^version =' Cargo.toml | head -n 1 | cut -d '"' -f 2)
+   sed -i "s/^Version:.*/Version:        $VERSION/" contrib/rpm/pgmoneta-mcp.spec
+
+   tar --exclude=rpmbuild --transform "s|^|pgmoneta-mcp-$VERSION/|" -czf rpmbuild/SOURCES/v$VERSION.tar.gz .
+   ```
+
+3. Build the RPM:
+   ```
+   rpmbuild --define "_topdir $(pwd)/rpmbuild" \
+            --define "_unitdir /usr/lib/systemd/system" \
+            --define "_bindir /usr/bin" \
+            --define "_sysconfdir /etc" \
+            -bb contrib/rpm/pgmoneta-mcp.spec
+   ```
+
+The generated RPMs will be in `rpmbuild/RPMS/`.
+
+## Installation
+
+Install the RPM using `dnf`:
+
+```
+sudo dnf install rpmbuild/RPMS/x86_64/pgmoneta-mcp-<version>-1.x86_64.rpm
+```
+
+or using `rpm`:
+
+```
+sudo rpm -ivh rpmbuild/RPMS/x86_64/pgmoneta-mcp-<version>-1.x86_64.rpm
+```
+
+The RPM installs the following:
+
+| Path | Description |
+| :--- | :---------- |
+| `/usr/bin/pgmoneta-mcp-server` | The MCP server binary |
+| `/usr/bin/pgmoneta-mcp-admin` | The admin tool binary |
+| `/etc/pgmoneta-mcp/pgmoneta-mcp.conf` | Main configuration file |
+| `/etc/pgmoneta-mcp/pgmoneta-mcp-users.conf` | User configuration file |
+| `/usr/lib/systemd/system/pgmoneta-mcp.service` | Systemd service unit |
+| `/var/log/pgmoneta-mcp/` | Log directory |
+
+A system user and group `pgmoneta` are created automatically during installation.
+
+## Uninstallation
+
+Stop the service first, then remove the package:
+
+```
+sudo systemctl stop pgmoneta-mcp
+sudo systemctl disable pgmoneta-mcp
+sudo dnf remove pgmoneta-mcp
+```
+
+or using `rpm`:
+
+```
+sudo systemctl stop pgmoneta-mcp
+sudo systemctl disable pgmoneta-mcp
+sudo rpm -e pgmoneta-mcp
+```
+
+Note that configuration files in `/etc/pgmoneta-mcp/` are preserved on removal since they are
+marked as `%config(noreplace)`. Remove them manually if no longer needed:
+
+```
+sudo rm -rf /etc/pgmoneta-mcp/
+sudo rm -rf /var/log/pgmoneta-mcp/
+```
+
+## Post-install setup
+
+After installing the RPM, perform the following steps to get pgmoneta-mcp running.
+
+### 1. Set the master key
+
+The master key is used to encrypt user passwords. Set it by running:
+
+```
+pgmoneta-mcp-admin master-key
+```
+
+You will be prompted to enter and confirm the master key.
+
+### 2. Add a user
+
+The RPM ships a placeholder user configuration file. Remove it first so that the admin tool
+can create a fresh one with the required `[admins]` section:
+
+```
+sudo rm /etc/pgmoneta-mcp/pgmoneta-mcp-users.conf
+```
+
+Then add a user that matches the user configured in your pgmoneta server. The user and password
+must match the ones registered with pgmoneta via `pgmoneta-admin`.
+
+```
+pgmoneta-mcp-admin user -U <username> -f /etc/pgmoneta-mcp/pgmoneta-mcp-users.conf add -P <password>
+```
+
+This creates the user configuration file with the required `[admins]` section. You can run this
+command again to update an existing user's password.
+
+### 3. Configure the server
+
+Edit the main configuration file:
+
+```
+sudo vi /etc/pgmoneta-mcp/pgmoneta-mcp.conf
+```
+
+The default configuration is:
+
+```
+[pgmoneta_mcp]
+port = 8000
+log_type = file
+log_level = info
+log_path = /var/log/pgmoneta-mcp/pgmoneta-mcp.log
+log_mode = append
+
+[pgmoneta]
+host = localhost
+port = 5000
+```
+
+Update the `[pgmoneta]` section to match your pgmoneta instance:
+
+* `host` - The address of the pgmoneta server
+* `port` - The management port of the pgmoneta server
+
+See [CONFIGURATION.md](./CONFIGURATION.md) for all available options.
+
+### 4. Verify pgmoneta is running
+
+Make sure the pgmoneta server is up and running in remote admin mode with the management port
+configured:
+
+```
+pgmoneta -A <your_user_conf.conf> -c <your_pgmoneta_conf.conf>
+```
+
+### 5. Start the service
+
+Enable and start pgmoneta-mcp:
+
+```
+sudo systemctl enable pgmoneta-mcp
+sudo systemctl start pgmoneta-mcp
+```
+
+Check the status:
+
+```
+sudo systemctl status pgmoneta-mcp
+```
+
+Check the logs:
+
+```
+sudo journalctl -u pgmoneta-mcp -f
+```
+
+or view the log file directly:
+
+```
+tail -f /var/log/pgmoneta-mcp/pgmoneta-mcp.log
+```


### PR DESCRIPTION
 This PR adds the necessary infrastructure to build and distribute `pgmoneta-mcp` as an RPM package, addressing issue #19.

 ### Changes:
 - Created a new `rpm/` directory containing:
   - `pgmoneta-mcp.spec`: Defines the package build process, dependencies, and installation paths.
   - `pgmoneta-mcp.conf`: Default configuration for system-wide installation (logging to `/var/log/pgmoneta-mcp/`).
   - `pgmoneta-mcp-users.conf`: Initial placeholder for user management.
   - `pgmoneta-mcp.service`: Systemd service unit to manage the MCP server.
 - Updated `.gitignore` to exclude `rpmbuild/` artifacts.
 - Added a new GitHub Actions workflow (`.github/workflows/rpm.yml`) to automate RPM builds using a Fedora container.

 ### Verification:
 - The RPM was successfully built locally using `rpmbuild`.
 - The package contents and file permissions were verified.
 - Installation and binary execution were tested inside a Docker container to ensure the server starts correctly with the packaged configuration.

### Test workflow build
you can try the CI build output using github actions here: https://github.com/Justxd22/pgmoneta_mcp/actions/runs/21806735262