### PR TITLE
[#33] Add Windows event logging support via winlog2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -529,6 +529,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
 name = "erased-serde"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -714,6 +720,12 @@ checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
  "foldhash",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
 name = "hashlink"
@@ -969,6 +981,16 @@ checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -1279,6 +1301,7 @@ dependencies = [
  "clap",
  "config",
  "home",
+ "log",
  "once_cell",
  "rand 0.9.1",
  "rmcp",
@@ -1293,6 +1316,7 @@ dependencies = [
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
+ "winlog2",
  "zeroize",
 ]
 
@@ -2112,10 +2136,12 @@ version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0dc8b1fb61449e27716ec0e1bdf0f6b8f3e8f6b05391e8497b8b6d7804ea6d8"
 dependencies = [
+ "indexmap",
  "serde_core",
  "serde_spanned",
  "toml_datetime",
  "toml_parser",
+ "toml_writer",
  "winnow",
 ]
 
@@ -2136,6 +2162,12 @@ checksum = "c0cbe268d35bdb4bb5a56a2de88d0ad0eb70af5384a99d648cd4b3d04039800e"
 dependencies = [
  "winnow",
 ]
+
+[[package]]
+name = "toml_writer"
+version = "1.0.6+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607"
 
 [[package]]
 name = "tower"
@@ -2450,6 +2482,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "widestring"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2731,12 +2769,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
+name = "winlog2"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbcb7337a45c2471af9792c45ba69cc6142ce6f71d56e1cc7190848247e9e8c2"
+dependencies = [
+ "log",
+ "thiserror 2.0.17",
+ "widestring",
+ "windows-sys 0.59.0",
+ "winreg",
+ "winresource",
+]
+
+[[package]]
 name = "winnow"
 version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "winreg"
+version = "0.55.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb5a765337c50e9ec252c2069be9bf91c7df47afb103b642ba3a53bf8101be97"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "winresource"
+version = "0.1.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e287ced0f21cd11f4035fe946fd3af145f068d1acb708afd248100f89ec7432d"
+dependencies = [
+ "toml",
+ "version_check",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,3 +53,6 @@ serde_ini = "0.2.0"
 tracing-appender = "0.2.4"
 syslog-tracing = "0.3.1"
 
+[target.'cfg(windows)'.dependencies]
+winlog2 = "0.3.2"
+log = "0.4"

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -17,8 +17,13 @@ use super::constant::{LogLevel, LogType};
 use crate::constant::LogMode;
 use anyhow::Context;
 use std::fs::OpenOptions;
+
 #[cfg(unix)]
 use syslog_tracing::Syslog;
+
+#[cfg(windows)]
+use winlog2;
+
 use tracing::level_filters::LevelFilter;
 use tracing_appender::non_blocking::WorkerGuard;
 use tracing_appender::rolling::RollingFileAppender;
@@ -134,6 +139,22 @@ impl Logger {
                 let (options, facility) = Default::default();
                 let syslog = Syslog::new(identity, options, facility).unwrap();
                 Ok((BoxMakeWriter::new(syslog), None))
+            }
+            #[cfg(windows)]
+            LogType::SYSLOG => {
+                if let Err(e) = winlog2::register("pgmoneta-mcp") {
+                    return Err(anyhow::anyhow!(
+                        "Failed to register Windows Event Log source: {}",
+                        e
+                    ));
+                }
+                if let Err(e) = winlog2::init("pgmoneta-mcp") {
+                    return Err(anyhow::anyhow!(
+                        "Failed to initialize Windows Event Logger: {}",
+                        e
+                    ));
+                }
+                Ok((BoxMakeWriter::new(std::io::sink), None))
             }
             _ => Err(anyhow::anyhow!("Invalid log type: {}", log_type)),
         }


### PR DESCRIPTION
Resolves #33 

**Description**
This PR implements native Windows Event Log support to achieve feature parity with the Unix syslog implementation. 

**Changes**
1. Added `winlog2` and `log` as Windows-only dependencies in `Cargo.toml`.
2. Updated `src/logging.rs` to initialize and register `winlog2` as the event source (`pgmoneta-mcp`) when `LogType::SYSLOG` is requested on Windows.
3. Routed `tracing` outputs appropriately on Windows to avoid crashing the subscriber while the `log` facade handles the actual OS-level event logging.

**Verification**
- `cargo build` succeeds on Windows.
- Verified that specifying `syslog` on Windows no longer falls through to the unsupported error, but instead initializes the Windows logger.