### PR TITLE
[#7] Add API documentation for configuration module

### DIFF
--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -20,40 +20,94 @@ use once_cell::sync::OnceCell;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
+/// Global, thread-safe instance of the application configuration.
+///
+/// This is initialized once at startup using [`load_configuration`] and accessed
+/// globally throughout the application lifecycle.
 pub static CONFIG: OnceCell<Configuration> = OnceCell::new();
+
+/// Type alias representing the parsed user configuration.
+///
+/// Maps a section name (e.g., username) to a dictionary of properties (e.g., password).
 pub type UserConf = HashMap<String, HashMap<String, String>>;
 
+/// The root configuration structure containing all application settings.
+///
+/// The configuration of `pgmoneta` is split into sections. This structure
+/// aggregates the `[pgmoneta_mcp]` and `[pgmoneta]` sections from the
+/// configuration file, along with the parsed admin users.
 #[derive(Clone, Debug, Deserialize)]
 pub struct Configuration {
+    /// The overall properties of the MCP server.
     pub pgmoneta_mcp: PgmonetaMcpConfiguration,
+    /// Settings to configure the connection with the remote `pgmoneta` server.
     pub pgmoneta: PgmonetaConfiguration,
-    pub admins: HashMap<String, String>, //username -> password
+    /// Parsed admin users mapping (username -> password).
+    pub admins: HashMap<String, String>,
 }
 
+/// Configuration properties for connecting to the remote `pgmoneta` instance.
+///
+/// This corresponds to the `[pgmoneta]` section in the configuration file.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct PgmonetaConfiguration {
+    /// The address of the pgmoneta instance (Required).
     pub host: String,
+    /// The port of the pgmoneta instance (Required).
     pub port: i32,
 }
 
+/// Configuration properties for the MCP server itself.
+///
+/// This corresponds to the `[pgmoneta_mcp]` section in the configuration file,
+/// where you configure the overall properties of the MCP server.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct PgmonetaMcpConfiguration {
+    /// The port the MCP server starts on. Default: 8000.
     #[serde(default = "default_port")]
     pub port: i32,
+    /// The log file location. Default: `pgmoneta_mcp.log`.
     #[serde(default = "default_log_path")]
     pub log_path: String,
+    /// The logging level (`trace`, `debug`, `info`, `warn`, `error`). Default: `info`.
     #[serde(default = "default_log_level")]
     pub log_level: String,
+    /// The logging type (`console`, `file`, `syslog`). Default: `console`.
     #[serde(default = "default_log_type")]
     pub log_type: String,
+    /// The timestamp format prefix for log messages. Default: `%Y-%m-%d %H:%M:%S`.
     #[serde(default = "default_log_line_prefix")]
     pub log_line_prefix: String,
+    /// Append to or create the log file (`append`, `create`). Default: `append`.
     #[serde(default = "default_log_mode")]
     pub log_mode: String,
+    /// The time after which log file rotation is triggered (when `log_type = file` and `log_mode = append`).
+    ///
+    /// Supported values:
+    /// * `0`: Never rotate
+    /// * `m`, `M`: Minutely rotation
+    /// * `h`, `H`: Hourly rotation
+    /// * `d`, `D`: Daily rotation
+    /// * `w`, `W`: Weekly rotation
+    ///
+    /// Default: `0`.
     #[serde(default = "default_log_rotation_age")]
     pub log_rotation_age: String,
 }
 
+/// Loads the main configuration and user configuration from the specified file paths.
+///
+/// The files are parsed as INI format and deserialized into the [`Configuration`] struct.
+///
+/// # Arguments
+///
+/// * `config_path` - The file path to the main configuration (e.g., `pgmoneta-mcp.conf`).
+/// * `user_path` - The file path to the user/admin configuration.
+///
+/// # Returns
+///
+/// Returns a populated [`Configuration`] object, or an error if the files cannot
+/// be read or parsed correctly.
 pub fn load_configuration(config_path: &str, user_path: &str) -> anyhow::Result<Configuration> {
     let conf = Config::builder()
         .add_source(config::File::with_name(config_path).format(FileFormat::Ini))
@@ -69,6 +123,15 @@ pub fn load_configuration(config_path: &str, user_path: &str) -> anyhow::Result<
     })
 }
 
+/// Loads only the user configuration from the specified file path.
+///
+/// # Arguments
+///
+/// * `user_path` - The file path to the user configuration file.
+///
+/// # Returns
+///
+/// Returns a parsed [`UserConf`] map, or an error if the file cannot be read or parsed.
 pub fn load_user_configuration(user_path: &str) -> anyhow::Result<UserConf> {
     let conf = Config::builder()
         .add_source(config::File::with_name(user_path).format(FileFormat::Ini))
@@ -81,6 +144,9 @@ pub fn load_user_configuration(user_path: &str) -> anyhow::Result<UserConf> {
         )
     })
 }
+
+// Private default value functions for Serde deserialization.
+// Note: Internal helper functions generally do not require public API documentation.
 
 fn default_port() -> i32 {
     8000


### PR DESCRIPTION
**Description**
This PR continues the work for Issue #7 by adding API-level documentation to the `configuration` module. 

**Changes**
* Added Rust standard (`///`) doc comments to all public structs, enums, and functions in `src/configuration.rs`.
* Mapped the property descriptions directly from `doc/CONFIGURATION.md` into the code so they appear accurately in the generated HTML documentation.

**Verification**
* Ran `cargo doc --no-deps` locally and verified correctly.
* Passed `cargo fmt` and `cargo clippy`.