### PR TITLE
[#9] admin: add pgmoneta-admin CLI parity

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -8,3 +8,4 @@ Noor Amjad <xdjust18@gmail.com>
 Austin Senna Wijaya <austinsenna@gmail.com>
 Trevor Jacob Mathews <trevorjacobmathews@gmail.com>
 Chen Shen <scisbeloved23@gmail.com>
+Nihal Kumar <collabwithnihal@gmail.com>

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ For now, this server allows you to query the backup info using natural language 
 
 ## Overview
 
-**pgmoneta MCP** is built upon [rmcp](https://docs.rs/rmcp/latest/rmcp/). It uses [SCRAM-SHA-256](https://datatracker.ietf.org/doc/html/rfc7677) to authenticate with pgmoneta server. We also provide an admin tool `pgmoneta-mcp-amdin` to help you manage users.
+**pgmoneta MCP** is built upon [rmcp](https://docs.rs/rmcp/latest/rmcp/). It uses [SCRAM-SHA-256](https://datatracker.ietf.org/doc/html/rfc7677) to authenticate with pgmoneta server. We also provide an admin tool `pgmoneta-mcp-admin` to help you manage users. For administration commands, see [ADMIN.md](doc/ADMIN.md).
 
 ## Build the project
 

--- a/doc/ADMIN.md
+++ b/doc/ADMIN.md
@@ -1,0 +1,99 @@
+# pgmoneta-mcp-admin user guide
+
+The **pgmoneta-mcp-admin** command line interface manages your users and master key for [**pgmoneta-mcp**](https://github.com/pgmoneta/pgmoneta-mcp).
+
+```
+pgmoneta-mcp-admin
+  Administration utility for pgmoneta-mcp
+
+Usage:
+  pgmoneta-mcp-admin [OPTIONS] [COMMAND]
+
+Options:
+  -f, --file <FILE>          The user configuration file
+  -U, --user <USER>          The user name
+  -P, --password <PASSWORD>  The password for the user
+  -g, --generate             Generate a password
+  -l, --length <LENGTH>      Password length (default: 64, ignored when --generate is not set) [default: 64]
+  -F, --format <FORMAT>      Output format [default: text] [possible values: text, json]
+  -h, --help                 Print help
+  -V, --version              Print version
+
+Commands:
+  master-key  Create or update the master key
+  user        Manage a specific user
+```
+
+## master-key
+
+Create or update the master key. The master key will be created in the pgmoneta-mcp user home directory under `~/.pgmoneta-mcp/master.key`
+
+Command
+
+```sh
+pgmoneta-mcp-admin master-key
+```
+
+## user add
+
+Add a user
+
+Command
+
+```sh
+pgmoneta-mcp-admin user add
+```
+
+Example
+
+```sh
+pgmoneta-mcp-admin -f /etc/pgmoneta-mcp/pgmoneta-mcp-users.conf -U admin user add
+```
+
+## user edit
+
+Update a user's password
+
+Command
+
+```sh
+pgmoneta-mcp-admin user edit
+```
+
+Example
+
+```sh
+pgmoneta-mcp-admin -f /etc/pgmoneta-mcp/pgmoneta-mcp-users.conf -U admin user edit
+```
+
+## user del
+
+Remove a user
+
+Command
+
+```sh
+pgmoneta-mcp-admin user del
+```
+
+Example
+
+```sh
+pgmoneta-mcp-admin -f /etc/pgmoneta-mcp/pgmoneta-mcp-users.conf -U admin user del
+```
+
+## user ls
+
+List all users
+
+Command
+
+```sh
+pgmoneta-mcp-admin user ls
+```
+
+Example
+
+```sh
+pgmoneta-mcp-admin -f /etc/pgmoneta-mcp/pgmoneta-mcp-users.conf user ls
+```

--- a/doc/DEVELOPERS.md
+++ b/doc/DEVELOPERS.md
@@ -119,9 +119,12 @@ cargo run --bin pgmoneta-mcp-server -- -c pgmoneta-mcp.conf -u pgmoneta-mcp-user
 ### Run built binaries directly
 
 ```bash
-./target/debug/pgmoneta-mcp-server -c <config> -u <users>
-./target/debug/pgmoneta-mcp-admin --help
+./target/debug/pgmoneta-mcp-server -c pgmoneta-mcp.conf -u pgmoneta-mcp-users.conf
+./target/debug/pgmoneta-mcp-admin -f pgmoneta-mcp-users.conf user ls
+./target/debug/pgmoneta-mcp-admin -f pgmoneta-mcp-users.conf -U admin user add
 ```
+
+For a full list of admin commands, see [ADMIN.md](ADMIN.md).
 
 ### Debugging
 

--- a/doc/GETTING_STARTED.md
+++ b/doc/GETTING_STARTED.md
@@ -38,7 +38,7 @@ Add the same user and password you added to pgmoneta server to pgmoneta MCP serv
 your user configuration file.
 
 ```
-pgmoneta-mcp-admin user -U <your_user_id> -f <your_mcp_user_conf.conf> add -P <your_password> 
+pgmoneta-mcp-admin -U <your_user_id> -f <your_mcp_user_conf.conf> -P <your_password> user add
 ```
 
 ## Configure pgmoneta MCP server

--- a/doc/man/pgmoneta-mcp-admin.1.rst
+++ b/doc/man/pgmoneta-mcp-admin.1.rst
@@ -1,0 +1,79 @@
+==================
+pgmoneta-mcp-admin
+==================
+
+---------------------------------------
+Administration utility for pgmoneta-mcp
+---------------------------------------
+
+:Manual section: 1
+
+SYNOPSIS
+========
+
+pgmoneta-mcp-admin [ OPTIONS ] <COMMAND>
+
+DESCRIPTION
+===========
+
+pgmoneta-mcp-admin is an administration utility for pgmoneta-mcp.
+
+OPTIONS
+=======
+
+-f, --file FILE
+  The user configuration file
+
+-U, --user USER
+  The user name
+
+-P, --password PASSWORD
+  The password for the user
+
+-g, --generate
+  Generate a password
+
+-l, --length LENGTH
+  Password length (default: 64)
+
+-F, --format FORMAT
+  Output format (text, json)
+
+-h, --help
+  Print help
+
+-V, --version
+  Print version
+
+COMMANDS
+========
+
+master-key
+  Create or update the master key
+
+user add
+  Add a new user to configuration file
+
+user del
+  Remove an existing user
+
+user edit
+  Change the password for an existing user
+
+user ls
+  List all available users
+
+REPORTING BUGS
+==============
+
+pgmoneta-mcp is maintained on GitHub at https://github.com/pgmoneta/pgmoneta-mcp
+
+COPYRIGHT
+=========
+
+pgmoneta-mcp is licensed under the GNU General Public License v3.0
+
+SEE ALSO
+========
+
+pgmoneta-mcp-server(1)

--- a/doc/man/pgmoneta-mcp-server.1.rst
+++ b/doc/man/pgmoneta-mcp-server.1.rst
@@ -1,0 +1,46 @@
+===================
+pgmoneta-mcp-server
+===================
+
+--------------------------------------------------------------------------------------
+A Model Context Protocol (MCP) server for pgmoneta, backup/restore tool for PostgreSQL
+--------------------------------------------------------------------------------------
+
+:Manual section: 1
+
+SYNOPSIS
+========
+
+pgmoneta-mcp-server [ OPTIONS ]
+
+DESCRIPTION
+===========
+
+pgmoneta-mcp-server is an MCP server for pgmoneta, providing a natural language interface for PostgreSQL backup information.
+
+OPTIONS
+=======
+
+-c, --conf CONF
+  Path to pgmoneta MCP configuration file (default: /etc/pgmoneta-mcp/pgmoneta-mcp.conf)
+
+-u, --users USERS
+  Path to pgmoneta MCP users configuration file (default: /etc/pgmoneta-mcp/pgmoneta-mcp-users.conf)
+
+-h, --help
+  Print help
+
+REPORTING BUGS
+==============
+
+pgmoneta-mcp is maintained on GitHub at https://github.com/pgmoneta/pgmoneta-mcp
+
+COPYRIGHT
+=========
+
+pgmoneta-mcp is licensed under the GNU General Public License v3.0
+
+SEE ALSO
+========
+
+pgmoneta-mcp-admin(1)

--- a/doc/man/pgmoneta-mcp-users.conf.5.rst
+++ b/doc/man/pgmoneta-mcp-users.conf.5.rst
@@ -1,0 +1,47 @@
+=======================
+pgmoneta-mcp-users.conf
+=======================
+
+------------------------------------------
+Users configuration file for pgmoneta-mcp
+------------------------------------------
+
+:Manual section: 5
+
+DESCRIPTION
+===========
+
+pgmoneta-mcp-users.conf is the users configuration file for pgmoneta-mcp.
+
+The file is split into different sections specified by the ``[`` and ``]`` characters. 
+Users are defined in the ``[users]`` section.
+
+The format is:
+
+``username = "password_hash"``
+
+Where the password hash is generated using SCRAM-SHA-256 (usually via the ``pgmoneta-mcp-admin`` utility).
+
+OPTIONS
+=======
+
+username
+  The name of the user.
+
+password_hash
+  The SCRAM-SHA-256 hash of the user's password.
+
+REPORTING BUGS
+==============
+
+pgmoneta-mcp is maintained on GitHub at https://github.com/pgmoneta/pgmoneta-mcp
+
+COPYRIGHT
+=========
+
+pgmoneta-mcp is licensed under the GNU General Public License v3.0
+
+SEE ALSO
+========
+
+pgmoneta-mcp-server(1), pgmoneta-mcp-admin(1), pgmoneta-mcp.conf(5)

--- a/doc/man/pgmoneta-mcp.conf.5.rst
+++ b/doc/man/pgmoneta-mcp.conf.5.rst
@@ -1,0 +1,65 @@
+=================
+pgmoneta-mcp.conf
+=================
+
+----------------------------------------
+Main configuration file for pgmoneta-mcp
+----------------------------------------
+
+:Manual section: 5
+
+DESCRIPTION
+===========
+
+pgmoneta-mcp.conf is the main configuration file for pgmoneta-mcp.
+
+The configuration of pgmoneta-mcp is split into sections using the ``[`` and ``]`` characters.
+
+The main section is called ``[pgmoneta_mcp]``, where you configure the overall properties of the MCP server.
+The other section is called ``[pgmoneta]``, where you configure the connection with the pgmoneta server.
+
+OPTIONS
+=======
+
+The options for the ``[pgmoneta_mcp]`` section are:
+
+port
+  The port the MCP server starts on. Default is 8000.
+
+log_type
+  The logging type (console, file, syslog). Default is console.
+
+log_level
+  The logging level, any of the strings ``trace``, ``debug``, ``info``, ``warn`` and ``error``. Default is info.
+
+log_path
+  The log file location. Default is pgmoneta_mcp.log.
+
+log_mode
+  Append to or create the log file, any of the strings (``append``, ``create``). Default is append.
+
+log_rotation_age
+  The time after which log file rotation is triggered. Used when log_type is file and log_mode is append. Any of the chars (``0``) for never rotate, (``m``, ``M``) for minutely rotation, (``h``, ``H``) for hourly rotation, (``d``, ``D``) for daily rotation and (``w``, ``W``) for weekly rotation. Default is 0.
+
+The options for the ``[pgmoneta]`` section are:
+
+host
+  The address of the pgmoneta instance. Mandatory.
+
+port
+  The port of the pgmoneta instance. Mandatory.
+
+REPORTING BUGS
+==============
+
+pgmoneta-mcp is maintained on GitHub at https://github.com/pgmoneta/pgmoneta-mcp
+
+COPYRIGHT
+=========
+
+pgmoneta-mcp is licensed under the GNU General Public License v3.0
+
+SEE ALSO
+========
+
+pgmoneta-mcp-server(1), pgmoneta-mcp-admin(1)

--- a/doc/manual/en/03-quickstart.md
+++ b/doc/manual/en/03-quickstart.md
@@ -1,0 +1,366 @@
+\newpage
+
+# Quick start
+
+Make sure that [**pgmoneta_mcp**][pgmoneta_mcp] is installed and in your path by using `pgmoneta-mcp-server --help`. You should see
+
+``` console
+pgmoneta-mcp-server 0.2.0
+  MCP server for pgmoneta
+
+Usage:
+  pgmoneta-mcp-server [OPTIONS]
+
+Options:
+  -c, --config <CONFIG>  Path to configuration file [default: /etc/pgmoneta-mcp/pgmoneta-mcp.conf]
+  -u, --users <USERS>    Path to users file [default: /etc/pgmoneta-mcp/pgmoneta-mcp-users.conf]
+  -h, --help             Print help
+  -V, --version          Print version
+```
+
+If you encounter any issues following the above steps, you can refer to the **Installation** chapter to see how to install or compile pgmoneta_mcp on your system.
+
+## Prerequisites
+
+You need to have PostgreSQL 14+ and pgmoneta installed and running. See pgmoneta's [manual](https://github.com/pgmoneta/pgmoneta/tree/main/doc/manual/en) on how to install and run pgmoneta.
+
+**Important**: You need to run pgmoneta in remote admin mode with management enabled. This allows pgmoneta_mcp to communicate with the pgmoneta server.
+
+In your pgmoneta configuration (`pgmoneta.conf`), ensure you have:
+
+``` ini
+[pgmoneta]
+management = 5000
+```
+
+And start pgmoneta with the admins file:
+
+``` sh
+pgmoneta -A pgmoneta_admins.conf -c pgmoneta.conf -u pgmoneta_users.conf
+```
+
+## Configuration
+
+### Master Key
+
+First, create a master key for pgmoneta_mcp. The master key is used to encrypt admin passwords stored in the configuration file.
+
+``` sh
+pgmoneta-mcp-admin master-key
+```
+
+This will prompt you to enter a master key (minimum 8 characters). The key will be stored in `~/.pgmoneta-mcp/master.key` with secure permissions (0600).
+
+For scripted use, you can provide the master key using the `PGMONETA_PASSWORD` environment variable:
+
+``` sh
+PGMONETA_PASSWORD=your_master_key pgmoneta-mcp-admin master-key
+```
+
+### User Configuration
+
+Add an admin user to pgmoneta_mcp. This should be the same user you configured in pgmoneta's admins file.
+
+``` sh
+pgmoneta-mcp-admin -f pgmoneta-mcp-users.conf -U admin user add
+```
+
+You will be prompted for the password. Alternatively, use the `-P` flag or `PGMONETA_PASSWORD` environment variable:
+
+``` sh
+pgmoneta-mcp-admin -f pgmoneta-mcp-users.conf -U admin -P secretpassword user add
+```
+
+The password will be encrypted using the master key and stored in `pgmoneta-mcp-users.conf`.
+
+### Server Configuration
+
+Create a configuration file called `pgmoneta-mcp.conf` with the following content:
+
+``` ini
+[pgmoneta_mcp]
+port = 8000
+log_type = file
+log_level = info
+log_path = /tmp/pgmoneta_mcp.log
+
+[pgmoneta]
+host = localhost
+port = 5000
+```
+
+**Configuration options**:
+
+- `port`: Port where the MCP server will listen (default: 8000)
+- `log_type`: Logging destination - `file`, `console`, or `syslog`
+- `log_level`: Log level - `trace`, `debug`, `info`, `warn`, or `error`
+- `log_path`: Path to log file (when `log_type = file`)
+- `[pgmoneta]` section:
+  - `host`: Hostname where pgmoneta server is running
+  - `port`: Management port of pgmoneta server (must match pgmoneta's `management` setting)
+
+See the **Configuration** chapter for all configuration options.
+
+## Running
+
+Start the MCP server using:
+
+``` sh
+pgmoneta-mcp-server -c pgmoneta-mcp.conf -u pgmoneta-mcp-users.conf
+```
+
+If this doesn't give an error, the MCP server is running and ready to accept connections.
+
+The server can be stopped by pressing Ctrl-C (`^C`) in the console where you started it, or by sending the `SIGTERM` signal to the process using `kill <pid>`.
+
+## Administration
+
+[**pgmoneta_mcp**][pgmoneta_mcp] has an administration tool called `pgmoneta-mcp-admin`, which is used to manage the master key and user accounts.
+
+You can see the commands it supports by using `pgmoneta-mcp-admin --help` which will give:
+
+``` console
+pgmoneta-mcp-admin 0.2.0
+  Administration utility for pgmoneta_mcp
+
+Usage:
+  pgmoneta-mcp-admin [OPTIONS] <COMMAND>
+
+Commands:
+  master-key  Create or update the master key
+  user        Manage users
+  help        Print this message or the help of the given subcommand(s)
+
+Options:
+  -f, --file <FILE>          Path to users file
+  -U, --user <USER>          Username
+  -P, --password <PASSWORD>  Password
+  -g, --generate             Generate a password
+  -l, --length <LENGTH>      Password length [default: 64]
+  -F, --format <FORMAT>      Output format (text or json) [default: text]
+  -h, --help                 Print help
+  -V, --version              Print version
+```
+
+### Master Key Management
+
+To create or update the master key:
+
+``` sh
+pgmoneta-mcp-admin master-key
+```
+
+To generate a random master key:
+
+``` sh
+pgmoneta-mcp-admin -g master-key
+```
+
+To generate a master key with specific length:
+
+``` sh
+pgmoneta-mcp-admin -g -l 32 master-key
+```
+
+### User Management
+
+**Add a user**:
+
+``` sh
+pgmoneta-mcp-admin -f pgmoneta-mcp-users.conf -U admin user add
+```
+
+**Add a user with generated password**:
+
+``` sh
+pgmoneta-mcp-admin -f pgmoneta-mcp-users.conf -U admin -g user add
+```
+
+**List all users**:
+
+``` sh
+pgmoneta-mcp-admin -f pgmoneta-mcp-users.conf user ls
+```
+
+**List users in JSON format**:
+
+``` sh
+pgmoneta-mcp-admin -f pgmoneta-mcp-users.conf -F json user ls
+```
+
+**Edit a user's password**:
+
+``` sh
+pgmoneta-mcp-admin -f pgmoneta-mcp-users.conf -U admin user edit
+```
+
+**Delete a user**:
+
+``` sh
+pgmoneta-mcp-admin -f pgmoneta-mcp-users.conf -U admin user del
+```
+
+## Connecting MCP Clients
+
+### VS Code with GitHub Copilot
+
+**Prerequisites**:
+- VS Code installed
+- GitHub Copilot extension installed
+
+**Add the server**:
+
+1. Open the Command Palette in VS Code (F1 or Ctrl+Shift+P)
+2. Type "MCP: Add Server"
+3. Configure your server with the following settings:
+   - Name: `pgmoneta`
+   - URL: `http://localhost:8000/mcp` (adjust host/port as needed)
+
+**Start the server**:
+
+1. Go to the Extensions tab
+2. Find your pgmoneta MCP server
+3. Click the gear icon
+4. Choose "Start Server"
+
+**Use the server**:
+
+Open a chat (Ctrl + Alt + I) and try:
+- "Say hello to the pgmoneta MCP server"
+- "Get information about the latest backup for server primary"
+- "List all backups for server primary"
+
+### Claude Desktop
+
+Add the following to your Claude Desktop configuration file:
+
+**macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`
+
+**Windows**: `%APPDATA%\Claude\claude_desktop_config.json`
+
+**Linux**: `~/.config/Claude/claude_desktop_config.json`
+
+``` json
+{
+  "mcpServers": {
+    "pgmoneta": {
+      "url": "http://localhost:8000/mcp"
+    }
+  }
+}
+```
+
+Restart Claude Desktop and the pgmoneta tools will be available.
+
+## Verifying the Setup
+
+To verify that everything is working correctly:
+
+1. **Check pgmoneta is running**:
+
+``` sh
+pgmoneta-cli -c pgmoneta.conf status
+```
+
+2. **Check pgmoneta_mcp server logs**:
+
+``` sh
+tail -f /tmp/pgmoneta_mcp.log
+```
+
+3. **Test MCP connection** (from your MCP client):
+   - Ask: "Say hello to the pgmoneta MCP server"
+   - Expected response: "Hello from pgmoneta MCP server!"
+
+4. **Test backup query** (from your MCP client):
+   - Ask: "Get information about the latest backup for server primary"
+   - Expected: Detailed backup information in JSON format
+
+## Troubleshooting
+
+### Connection Refused
+
+If you get "Connection refused" errors:
+
+1. Verify pgmoneta is running with management enabled:
+
+``` sh
+ps aux | grep pgmoneta
+```
+
+2. Check if the management port is listening:
+
+``` sh
+netstat -tuln | grep 5000
+```
+
+3. Verify firewall settings allow connections to the management port
+
+### Authentication Failed
+
+If authentication fails:
+
+1. Verify the admin user exists in pgmoneta:
+
+``` sh
+pgmoneta-admin -f pgmoneta_admins.conf user ls
+```
+
+2. Verify the same user exists in pgmoneta_mcp:
+
+``` sh
+pgmoneta-mcp-admin -f pgmoneta-mcp-users.conf user ls
+```
+
+3. Ensure passwords match between pgmoneta and pgmoneta_mcp
+
+### Master Key Issues
+
+If you get master key errors:
+
+1. Check if master key file exists:
+
+``` sh
+ls -la ~/.pgmoneta-mcp/master.key
+```
+
+2. Verify permissions (should be 0600):
+
+``` sh
+chmod 600 ~/.pgmoneta-mcp/master.key
+```
+
+3. Recreate the master key if needed:
+
+``` sh
+pgmoneta-mcp-admin master-key
+```
+
+## Next Steps
+
+Next steps in improving pgmoneta_mcp's configuration could be:
+
+* Read the manual
+* Update `pgmoneta-mcp.conf` with the required settings for your system
+* Configure logging levels appropriate for your environment
+* Set up multiple admin users for team access
+* Integrate with your preferred MCP client
+
+See [Configuration][configuration] for more information on these subjects.
+
+## Closing
+
+The [pgmoneta_mcp](https://github.com/pgmoneta/pgmoneta_mcp) community hopes that you find the project interesting.
+
+Feel free to
+
+* [Ask a question](https://github.com/pgmoneta/pgmoneta_mcp/discussions)
+* [Raise an issue](https://github.com/pgmoneta/pgmoneta_mcp/issues)
+* [Submit a feature request](https://github.com/pgmoneta/pgmoneta_mcp/issues)
+* [Write a code submission](https://github.com/pgmoneta/pgmoneta_mcp/pulls)
+
+All contributions are most welcome!
+
+Please, consult our [Code of Conduct](../CODE_OF_CONDUCT.md) policies for interacting in our community.
+
+Consider giving the project a [star](https://github.com/pgmoneta/pgmoneta_mcp/stargazers) on [GitHub](https://github.com/pgmoneta/pgmoneta_mcp/) if you find it useful. And, feel free to follow the project on [X](https://x.com/pgmoneta/) as well.

--- a/doc/manual/en/76-test.md
+++ b/doc/manual/en/76-test.md
@@ -2,19 +2,126 @@
 
 ## Test
 
+### Overview
+
+**pgmoneta_mcp** includes comprehensive test coverage at multiple levels:
+
+- **Unit tests**: Test individual functions and modules in isolation
+- **Integration tests**: Test end-to-end functionality with a running pgmoneta server
+- **Container-based tests**: Automated testing with Docker/Podman containers
+
+All tests are written using Rust's built-in testing framework and can be run using `cargo test`.
+
 ### Dependencies
 
 To install all the required dependencies (rust, make and cargo), simply run `<PATH_TO_PGMONETA_MCP>/test/check.sh setup`. You need to install docker or podman
 separately. The script currently only works on Linux system (we recommend Fedora 39+). 
 
+**Required dependencies**:
+- Rust toolchain (stable)
+- cargo
+- docker or podman (for container-based tests)
+- make (optional, for convenience scripts)
+
+### Test Types
+
+#### Unit Tests
+
+Unit tests are embedded in the source files using `#[cfg(test)]` modules. They test individual functions and modules without external dependencies.
+
+**Running unit tests**:
+```bash
+cargo test --lib
+```
+
+**Running specific unit test**:
+```bash
+cargo test test_base64_encode_decode
+```
+
+**Running tests with output**:
+```bash
+cargo test -- --nocapture
+```
+
+**Available unit test modules**:
+
+**Security module tests** (`src/security.rs`):
+- `test_base64_encode_decode`: Base64 encoding/decoding
+- `test_encrypt_decrypt`: Encryption/decryption roundtrip
+- `test_encrypt_decrypt_empty_string`: Empty string encryption
+- `test_encrypt_decrypt_large_text`: Large text encryption (10KB)
+- `test_encrypt_decrypt_unicode`: Unicode text encryption
+- `test_decrypt_with_wrong_key`: Wrong key detection
+- `test_decrypt_invalid_base64`: Invalid Base64 handling
+- `test_decrypt_truncated_ciphertext`: Truncated data handling
+- `test_generate_password_default_length`: Password generation (64 chars)
+- `test_generate_password_custom_length`: Password generation (32 chars)
+- `test_generate_password_contains_valid_chars`: Character set validation
+- `test_generate_password_min_length`: Minimum length (1 char)
+- `test_generate_password_uniqueness`: Random uniqueness
+- `test_encrypt_different_nonces`: Nonce randomness
+
+**Client module tests** (`src/client.rs`):
+- `test_build_request_header`: Request header construction
+- `test_build_request_header_different_commands`: Command differentiation
+- `test_request_serialization`: JSON serialization
+- `test_request_header_serialization`: Header serialization
+- `test_write_request_format`: Wire format validation
+- `test_timestamp_format`: Timestamp format validation
+- `test_request_clone`: Request cloning
+
+#### Integration Tests
+
+Integration tests are located in `tests/integration_test.rs` and test the complete system with a running pgmoneta server.
+
+**Running integration tests**:
+```bash
+# Run all integration tests (requires pgmoneta server)
+cargo test --test integration_test -- --ignored
+
+# Run specific integration test
+cargo test --test integration_test test_handler_say_hello -- --ignored
+```
+
+**Note**: Integration tests are marked with `#[ignore]` because they require:
+- Running pgmoneta server on localhost:2345
+- Configured admin user
+- Master key set up
+- At least one server configured in pgmoneta
+
+**Available integration tests**:
+
+- `test_handler_say_hello`: Test basic MCP handler response
+- `test_handler_get_backup_info_latest`: Get latest backup information
+- `test_handler_get_backup_info_oldest`: Get oldest backup information
+- `test_handler_list_backups`: List backups in ascending order
+- `test_handler_list_backups_descending`: List backups in descending order
+- `test_handler_initialization`: Handler initialization
+- `test_security_util_creation`: Security utility creation
+- `test_password_generation`: Password generation
+- `test_encryption_roundtrip`: Encryption roundtrip
+
 ### Running Tests
 
+#### Quick Test Run (Unit Tests Only)
+
+```bash
+cargo test
+```
+
+This runs all unit tests without requiring external dependencies.
+
+#### Full Test Suite (with Container)
+
 To run the tests, simply run `<PATH_TO_PGMONETA_MCP>/test/check.sh`. The script will build a composed image containing PostgreSQL 18 and pgmoneta, start a docker/podman container using the image (so make sure you at least have one of them installed and have the corresponding container engine started) and run tests. 
+
 The containerized pgmoneta-postgres composed server will have a `backup_user` user with the replication attribute, a normal user `myuser` and a database `mydb`.
 
 The script then runs pgmoneta_mcp tests in your local environment. The tests are run locally so that you may leverage stdout to debug.
 
-### Build only (no tests) 
+#### Build only (no tests) 
+
 Run `<PATH_TO_PGMONETA>/test/check.sh build` to prepare the test environment (image, master key generation) without running tests. This always does a full build.
 
 ### Fast Iteration of testing
@@ -29,11 +136,144 @@ To run integration tests only, simply run `<PATH_TO_PGMONETA_MCP>/test/check.sh 
 ### Single test or module
 Run `<PATH_TO_PGMONETA>/test/check.sh test -m <test_name>`. The script assumes the environment is up, so you need to run the full suite first. For quick iteration, run `<PATH_TO_PGMONETA>/test/check.sh build` once, then `<PATH_TO_PGMONETA>/test/check.sh test -m <module_name>` or `<PATH_TO_PGMONETA>/test/check.sh test` repeatedly.
 
+#### Parallel vs Sequential Testing
+
+By default, Rust runs tests in parallel. For integration tests that share resources, run sequentially:
+
+```bash
+cargo test --test integration_test -- --test-threads=1 --ignored
+```
+
 It is recommended that you **ALWAYS** run tests before raising PR.
 
-### Add Testcases
+### Writing New Tests
 
-To add an additional testcase, check [Test Organization in Rust](https://doc.rust-lang.org/book/ch11-03-test-organization.html)
+#### Adding Unit Tests
+
+Unit tests should be added to the same file as the code they test, in a `#[cfg(test)]` module at the end of the file:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_my_function() {
+        let result = my_function(input);
+        assert_eq!(result, expected);
+    }
+
+    #[tokio::test]
+    async fn test_async_function() {
+        let result = async_function().await;
+        assert!(result.is_ok());
+    }
+}
+```
+
+**Best practices**:
+- Test both success and failure cases
+- Test edge cases (empty input, large input, invalid input)
+- Test error handling
+- Use descriptive test names
+- Keep tests focused and independent
+- Use `assert_eq!`, `assert!`, `assert_ne!` for clear assertions
+
+#### Adding Integration Tests
+
+Integration tests should be added to `tests/integration_test.rs`:
+
+```rust
+#[tokio::test]
+#[ignore] // Mark as ignored if requires external dependencies
+async fn test_new_feature() {
+    // Initialize configuration if needed
+    if let Err(e) = init_config() {
+        eprintln!("Skipping test: {}", e);
+        return;
+    }
+
+    // Test implementation
+    let handler = PgmonetaHandler::new();
+    let result = handler.new_feature().await;
+    
+    assert!(result.is_ok());
+}
+```
+
+**Best practices**:
+- Mark tests requiring external dependencies with `#[ignore]`
+- Handle missing configuration gracefully
+- Provide clear error messages
+- Clean up resources after tests
+- Test realistic scenarios
+
+For more details, check [Test Organization in Rust](https://doc.rust-lang.org/book/ch11-03-test-organization.html)
+
+### Test Coverage
+
+To generate test coverage reports:
+
+```bash
+# Install tarpaulin
+cargo install cargo-tarpaulin
+
+# Generate coverage report
+cargo tarpaulin --out Html --output-dir coverage
+```
+
+Open `coverage/index.html` to view the coverage report.
+
+**Current coverage areas**:
+- Security module: Encryption, decryption, key management, password generation
+- Client module: Request building, serialization, wire format
+- Handler module: MCP tool routing, response translation
+- Configuration module: Configuration loading and validation
+
+### Debugging Tests
+
+#### Enable Debug Logging
+
+Set the `RUST_LOG` environment variable:
+
+```bash
+RUST_LOG=debug cargo test -- --nocapture
+```
+
+#### Run Single Test with Output
+
+```bash
+cargo test test_name -- --nocapture --test-threads=1
+```
+
+#### Use `dbg!` Macro
+
+```rust
+#[test]
+fn test_debug() {
+    let value = compute_value();
+    dbg!(&value); // Prints value with file and line number
+    assert_eq!(value, expected);
+}
+```
+
+#### Conditional Compilation for Test Code
+
+```rust
+#[cfg(test)]
+fn test_helper() {
+    // Helper function only available in tests
+}
+```
+
+### Continuous Integration
+
+Tests are automatically run in CI/CD pipelines. The CI configuration includes:
+
+- **Formatting check**: `cargo fmt --all --check`
+- **Linting**: `cargo clippy --all-targets --all-features -- -D warnings`
+- **Unit tests**: `cargo test --lib`
+- **Build verification**: `cargo build --release`
 
 ### Cleanup
 
@@ -44,3 +284,54 @@ nukes all the docker volumes.
 ### Port
 
 By default, the container exposes port 5432 for pgmoneta-mcp to connect to.
+
+### Troubleshooting
+
+#### Tests Fail with "Configuration not found"
+
+Ensure configuration files are in the expected locations:
+- `pgmoneta-mcp.conf`
+- `pgmoneta-mcp-users.conf`
+- `~/.pgmoneta-mcp/master.key`
+
+#### Integration Tests Timeout
+
+Increase timeout or check if pgmoneta server is running:
+
+```bash
+# Check if pgmoneta is running
+ps aux | grep pgmoneta
+
+# Check if port is listening
+netstat -tuln | grep 2345
+```
+
+#### Tests Fail with "Connection refused"
+
+Ensure pgmoneta server is running and accessible:
+
+```bash
+# Start pgmoneta server
+pgmoneta -c /path/to/pgmoneta.conf
+
+# Or use the test container
+./test/check.sh build
+```
+
+#### Permission Denied on Master Key
+
+Fix file permissions:
+
+```bash
+chmod 600 ~/.pgmoneta-mcp/master.key
+```
+
+### Test Maintenance
+
+- Keep tests up to date with code changes
+- Remove obsolete tests
+- Update test data when APIs change
+- Document test requirements
+- Review test failures in CI/CD
+- Add tests for bug fixes
+- Maintain test coverage above 80%

--- a/doc/manual/en/79-mcp-api.md
+++ b/doc/manual/en/79-mcp-api.md
@@ -1,0 +1,433 @@
+\newpage
+
+## MCP API
+
+### Overview
+
+**pgmoneta_mcp** implements the [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) to enable AI assistants and language models to interact with pgmoneta backup servers. The MCP server exposes pgmoneta's backup management capabilities through a standardized interface that can be consumed by MCP clients.
+
+The MCP implementation is built on top of the [rmcp](https://docs.rs/rmcp/latest/rmcp/) Rust library and provides:
+
+- **Tool-based interface**: Exposes pgmoneta operations as MCP tools
+- **SCRAM-SHA-256 authentication**: Secure authentication with pgmoneta server
+- **JSON-based communication**: Structured request/response format
+- **Automatic data translation**: Converts raw pgmoneta responses into human-readable formats
+
+### Architecture
+
+The MCP server architecture consists of several key components:
+
+```
+┌─────────────────┐
+│   MCP Client    │ (Claude, ChatGPT, etc.)
+│  (AI Assistant) │
+└────────┬────────┘
+         │ MCP Protocol
+         │ (JSON-RPC)
+         ▼
+┌─────────────────┐
+│ PgmonetaHandler │ ◄─── Handles MCP requests
+│   (handler.rs)  │      Routes to appropriate tools
+└────────┬────────┘
+         │
+         ▼
+┌─────────────────┐
+│ PgmonetaClient  │ ◄─── Manages communication
+│   (client.rs)   │      with pgmoneta server
+└────────┬────────┘
+         │ TCP + SCRAM-SHA-256
+         │
+         ▼
+┌─────────────────┐
+│ pgmoneta server │ ◄─── Backup/restore operations
+└─────────────────┘
+```
+
+### Core Components
+
+#### PgmonetaHandler
+
+**Location**: `src/handler.rs`
+
+The `PgmonetaHandler` is the main entry point for MCP requests. It implements the `ServerHandler` trait from rmcp and routes incoming tool calls to the appropriate internal methods.
+
+**Key responsibilities**:
+- Implements MCP server initialization and handshake
+- Defines available MCP tools using the `#[tool]` macro
+- Parses and validates pgmoneta server responses
+- Translates raw numeric values into human-readable formats
+- Returns standardized `CallToolResult` responses
+
+**Example tool definition**:
+```rust
+#[tool(
+    description = "Get information of a backup using given backup ID and server name"
+)]
+async fn get_backup_info(
+    &self,
+    Parameters(args): Parameters<InfoRequest>,
+) -> Result<CallToolResult, McpError> {
+    let result = self._get_backup_info(args).await?;
+    Self::_generate_call_tool_result(&result)
+}
+```
+
+#### PgmonetaClient
+
+**Location**: `src/client.rs`
+
+The `PgmonetaClient` handles low-level TCP communication with the pgmoneta server. It manages the request/response lifecycle including authentication, payload serialization, and response parsing.
+
+**Key responsibilities**:
+- Builds request headers with metadata (command, timestamp, format, etc.)
+- Establishes authenticated TCP connections using SCRAM-SHA-256
+- Serializes requests to JSON and writes to TCP stream
+- Reads and deserializes responses from TCP stream
+- Manages connection lifecycle
+
+**Request structure**:
+```rust
+struct PgmonetaRequest<R> {
+    header: RequestHeader,  // Metadata
+    request: R,             // Tool-specific payload
+}
+
+struct RequestHeader {
+    command: u32,           // Command code (e.g., Command::INFO)
+    client_version: String, // MCP client version
+    output_format: u8,      // Response format (JSON)
+    timestamp: String,      // Request timestamp
+    compression: u8,        // Compression type (NONE)
+    encryption: u8,         // Encryption type (NONE)
+}
+```
+
+### Available MCP Tools
+
+#### say_hello
+
+**Description**: Simple ping tool to verify MCP server connectivity.
+
+**Parameters**: None
+
+**Returns**: Greeting message
+
+**Example**:
+```json
+{
+  "tool": "say_hello"
+}
+```
+
+#### get_backup_info
+
+**Description**: Retrieves detailed information about a specific backup.
+
+**Parameters**:
+- `username` (string, required): pgmoneta admin username
+- `server` (string, required): Server name as configured in pgmoneta
+- `backup_id` (string, required): Backup identifier (can be backup label, "newest", "latest", or "oldest")
+
+**Returns**: Comprehensive backup information including:
+- Backup label and timestamp
+- Backup size and restore size
+- Compression and encryption settings
+- LSN (Log Sequence Number) information
+- WAL file details
+- Checkpoint information
+- Server configuration
+
+**Example**:
+```json
+{
+  "tool": "get_backup_info",
+  "arguments": {
+    "username": "admin",
+    "server": "primary",
+    "backup_id": "latest"
+  }
+}
+```
+
+**Response structure**:
+```json
+{
+  "Outcome": "Success",
+  "BackupInfo": {
+    "Server": "primary",
+    "Label": "20260304123045",
+    "BackupSize": "1.2 GB",
+    "RestoreSize": "1.5 GB",
+    "Compression": "zstd",
+    "Encryption": "aes-256-cbc",
+    "StartHiLSN": "0x1A2B3C4D",
+    "StartLoLSN": "0x5E6F7890",
+    ...
+  }
+}
+```
+
+#### list_backups
+
+**Description**: Lists all available backups for a specified server.
+
+**Parameters**:
+- `username` (string, required): pgmoneta admin username
+- `server` (string, required): Server name as configured in pgmoneta
+- `sort_order` (string, optional): Sort order - "asc" (default) or "desc"
+
+**Returns**: Array of backup summaries with key information for each backup.
+
+**Example**:
+```json
+{
+  "tool": "list_backups",
+  "arguments": {
+    "username": "admin",
+    "server": "primary",
+    "sort_order": "desc"
+  }
+}
+```
+
+**Response structure**:
+```json
+{
+  "Outcome": "Success",
+  "Backups": [
+    {
+      "Label": "20260304123045",
+      "BackupSize": "1.2 GB",
+      "RestoreSize": "1.5 GB",
+      "Compression": "zstd",
+      "Encryption": "aes-256-cbc"
+    },
+    ...
+  ]
+}
+```
+
+### Data Translation
+
+The MCP server automatically translates raw pgmoneta responses into human-readable formats:
+
+#### File Size Translation
+
+Raw byte counts are converted to human-readable formats:
+- `BackupSize`: `1234567890` → `"1.2 GB"`
+- `RestoreSize`: `1610612736` → `"1.5 GB"`
+- `TotalSpace`, `FreeSpace`, `UsedSpace`, etc.
+
+#### LSN Translation
+
+Log Sequence Numbers are converted to hexadecimal strings:
+- `StartHiLSN`: `439041101` → `"0x1A2B3C4D"`
+- `StartLoLSN`: `1583691920` → `"0x5E6F7890"`
+- `CheckpointHiLSN`, `CheckpointLoLSN`, `EndHiLSN`, `EndLoLSN`
+
+#### Enum Translation
+
+Numeric enum values are translated to descriptive strings:
+
+**Compression types**:
+- `0` → `"none"`
+- `1` → `"gzip"`
+- `2` → `"zstd"`
+- `3` → `"lz4"`
+- `4` → `"bzip2"`
+
+**Encryption types**:
+- `0` → `"none"`
+- `1` → `"aes-256-cbc"`
+- `2` → `"aes-192-cbc"`
+- `3` → `"aes-128-cbc"`
+- `4` → `"aes-256-ctr"`
+- `5` → `"aes-192-ctr"`
+- `6` → `"aes-128-ctr"`
+
+**Error codes**:
+- `0` → `"Success"`
+- `1` → `"Error"`
+- `2` → `"Allocation error"`
+- And many more (see `constant.rs` for full list)
+
+### Error Handling
+
+The MCP server uses the `McpError` type from rmcp for standardized error responses:
+
+**Error types**:
+- `ParseError`: Failed to parse pgmoneta response
+- `InternalError`: Internal server error
+- `InvalidParams`: Invalid tool parameters
+- `MethodNotFound`: Unknown tool requested
+
+**Example error response**:
+```json
+{
+  "error": {
+    "code": -32603,
+    "message": "Failed to parse result",
+    "data": {
+      "details": "Invalid JSON format"
+    }
+  }
+}
+```
+
+### Authentication
+
+The MCP server uses SCRAM-SHA-256 for authentication with the pgmoneta server:
+
+1. **User configuration**: Admin users are configured in `pgmoneta-mcp-users.conf`
+2. **Password encryption**: Passwords are encrypted using AES-256-GCM with a master key
+3. **Master key**: Stored in `~/.pgmoneta-mcp/master.key` with 0600 permissions
+4. **SCRAM handshake**: Performed during TCP connection establishment
+
+See [Security API documentation](80-security-api.md) for detailed information.
+
+### Configuration
+
+The MCP server requires two configuration files:
+
+**pgmoneta-mcp.conf**:
+```ini
+[pgmoneta]
+host = localhost
+port = 2345
+
+[log]
+type = file
+level = info
+path = /tmp/pgmoneta-mcp.log
+```
+
+**pgmoneta-mcp-users.conf**:
+```ini
+[admin]
+password = <encrypted_password_base64>
+```
+
+See [Configuration documentation](../CONFIGURATION.md) for complete details.
+
+### Usage Example
+
+**Starting the MCP server**:
+```bash
+pgmoneta-mcp-server -c pgmoneta-mcp.conf -u pgmoneta-mcp-users.conf
+```
+
+**MCP client interaction** (pseudo-code):
+```python
+# Connect to MCP server
+client = MCPClient("http://localhost:8080/mcp")
+
+# Initialize connection
+client.initialize()
+
+# Call tool to get backup info
+result = client.call_tool(
+    "get_backup_info",
+    {
+        "username": "admin",
+        "server": "primary",
+        "backup_id": "latest"
+    }
+)
+
+# Process result
+print(f"Latest backup: {result['BackupInfo']['Label']}")
+print(f"Size: {result['BackupInfo']['BackupSize']}")
+```
+
+### Extending the MCP Server
+
+To add a new MCP tool:
+
+1. **Define request structure** in `src/handler/` (e.g., `new_tool.rs`):
+```rust
+#[derive(Deserialize, JsonSchema)]
+pub struct NewToolRequest {
+    pub username: String,
+    pub param1: String,
+    // ... other parameters
+}
+```
+
+2. **Implement internal method** in `PgmonetaHandler`:
+```rust
+async fn _new_tool(&self, args: NewToolRequest) -> Result<String, McpError> {
+    let result = PgmonetaClient::forward_request(
+        &args.username,
+        Command::NEW_COMMAND,
+        args
+    ).await?;
+    Ok(result)
+}
+```
+
+3. **Add tool definition** with `#[tool]` macro:
+```rust
+#[tool(description = "Description of new tool")]
+async fn new_tool(
+    &self,
+    Parameters(args): Parameters<NewToolRequest>,
+) -> Result<CallToolResult, McpError> {
+    let result = self._new_tool(args).await?;
+    Self::_generate_call_tool_result(&result)
+}
+```
+
+4. **Add command constant** in `src/constant.rs`:
+```rust
+impl Command {
+    pub const NEW_COMMAND: u32 = 123;
+}
+```
+
+### Debugging
+
+Enable debug logging to see detailed request/response information:
+
+**In configuration**:
+```ini
+[log]
+level = debug
+```
+
+**Debug output includes**:
+- TCP connection establishment
+- SCRAM authentication handshake
+- Request serialization
+- Response parsing
+- Data translation steps
+
+**Example debug log**:
+```
+DEBUG Connected to server, username=admin
+DEBUG Sent request to server, request=PgmonetaRequest { ... }
+DEBUG Received response, length=1234
+DEBUG Translated compression: 2 -> "zstd"
+DEBUG Translated backup size: 1234567890 -> "1.2 GB"
+```
+
+### Performance Considerations
+
+- **Connection pooling**: Each tool call establishes a new TCP connection. For high-frequency usage, consider implementing connection pooling.
+- **Response caching**: Backup information changes infrequently. Consider caching responses with appropriate TTL.
+- **Timeout handling**: Configure appropriate timeouts for long-running operations.
+- **Concurrent requests**: The server handles concurrent MCP requests safely.
+
+### Security Considerations
+
+- **Master key protection**: The master key file must have 0600 permissions
+- **Password encryption**: All passwords are encrypted at rest using AES-256-GCM
+- **SCRAM-SHA-256**: Strong authentication mechanism prevents password sniffing
+- **Admin-only access**: Only configured admin users can access pgmoneta operations
+- **Audit logging**: All operations are logged with username and timestamp
+
+### References
+
+- [Model Context Protocol Specification](https://modelcontextprotocol.io/)
+- [rmcp Documentation](https://docs.rs/rmcp/latest/rmcp/)
+- [SCRAM-SHA-256 RFC](https://datatracker.ietf.org/doc/html/rfc7677)
+- [pgmoneta Documentation](https://pgmoneta.github.io/)

--- a/doc/manual/en/80-security-api.md
+++ b/doc/manual/en/80-security-api.md
@@ -1,0 +1,571 @@
+\newpage
+
+## Security API
+
+### Overview
+
+The **Security API** provides cryptographic operations, authentication mechanisms, and secure key management for **pgmoneta_mcp**. It implements industry-standard security practices to protect sensitive data at rest and in transit.
+
+The security module is defined and implemented in `src/security.rs` and provides:
+
+- **AES-256-GCM encryption**: For encrypting passwords and sensitive data at rest
+- **SCRAM-SHA-256 authentication**: For secure authentication with pgmoneta server
+- **Master key management**: Secure storage and loading of encryption keys
+- **Password generation**: Cryptographically secure random password generation
+- **Base64 encoding/decoding**: For encoding binary data in configuration files
+
+### Architecture
+
+```
+┌──────────────────────────────────────┐
+│         SecurityUtil                 │
+├──────────────────────────────────────┤
+│  Master Key Management               │
+│  - load_master_key()                 │
+│  - write_master_key()                │
+│                                      │
+│  Encryption/Decryption               │
+│  - encrypt_to_base64_string()        │
+│  - decrypt_from_base64_string()      │
+│  - encrypt_text()                    │
+│  - decrypt_text()                    │
+│                                      │
+│  Authentication                      │
+│  - connect_to_server()               │
+│  - SCRAM-SHA-256 handshake           │
+│                                      │
+│  Utilities                           │
+│  - generate_password()               │
+│  - base64_encode()                   │
+│  - base64_decode()                   │
+└──────────────────────────────────────┘
+```
+
+### SecurityUtil Structure
+
+The `SecurityUtil` struct is the main entry point for all security operations:
+
+```rust
+pub struct SecurityUtil {
+    base64_engine: engine::GeneralPurpose,
+}
+```
+
+**Creating an instance**:
+```rust
+let security_util = SecurityUtil::new();
+```
+
+### Master Key Management
+
+The master key is used to encrypt/decrypt admin passwords stored in the user configuration file. It is stored in `~/.pgmoneta-mcp/master.key` with strict file permissions (0600 on Unix systems).
+
+#### load_master_key
+
+**Signature**:
+```rust
+pub fn load_master_key(&self) -> anyhow::Result<Zeroizing<Vec<u8>>>
+```
+
+**Description**: Loads the master key from the filesystem and returns it wrapped in a `Zeroizing` container that automatically zeros the memory when dropped.
+
+**Location**: `~/.pgmoneta-mcp/master.key`
+
+**Security features**:
+- Automatically enforces 0600 permissions on Unix systems
+- Returns key wrapped in `Zeroizing` to prevent key material from remaining in memory
+- Base64 decodes the stored key
+
+**Usage**:
+```rust
+let security_util = SecurityUtil::new();
+let master_key = security_util.load_master_key()?;
+// Use master_key for encryption/decryption
+// Key is automatically zeroed when master_key goes out of scope
+```
+
+**Error conditions**:
+- Home directory cannot be determined
+- Master key file does not exist
+- File permissions are too permissive (automatically corrected)
+- Invalid Base64 encoding
+
+#### write_master_key
+
+**Signature**:
+```rust
+pub fn write_master_key(&self, key: &str) -> anyhow::Result<()>
+```
+
+**Description**: Writes a new master key to the filesystem with secure permissions.
+
+**Security features**:
+- Creates parent directory if it doesn't exist
+- Sets file permissions to 0600 on Unix systems (owner read/write only)
+- Base64 encodes the key before writing
+
+**Usage**:
+```rust
+let security_util = SecurityUtil::new();
+let master_key = "my-secret-master-key-32-bytes!";
+security_util.write_master_key(master_key)?;
+```
+
+**Best practices**:
+- Generate master key using cryptographically secure random number generator
+- Use at least 32 bytes (256 bits) for the master key
+- Never hardcode master keys in source code
+- Back up master key securely (losing it means losing access to encrypted passwords)
+
+### Encryption and Decryption
+
+The security module uses **AES-256-GCM** (Galois/Counter Mode) for authenticated encryption, which provides both confidentiality and integrity protection.
+
+#### Encryption Process
+
+1. **Key derivation**: Master key is derived using scrypt with a random salt
+2. **Nonce generation**: Random 12-byte nonce is generated
+3. **Encryption**: Plaintext is encrypted using AES-256-GCM
+4. **Packaging**: Nonce + Salt + Ciphertext are concatenated and Base64 encoded
+
+#### encrypt_to_base64_string
+
+**Signature**:
+```rust
+pub fn encrypt_to_base64_string(
+    &self,
+    plain_text: &[u8],
+    master_key: &[u8],
+) -> anyhow::Result<String>
+```
+
+**Description**: Encrypts plaintext and returns a Base64-encoded string containing nonce, salt, and ciphertext.
+
+**Parameters**:
+- `plain_text`: Data to encrypt (typically a password)
+- `master_key`: Master key for encryption (typically 32 bytes)
+
+**Returns**: Base64-encoded string in format: `base64(nonce || salt || ciphertext)`
+
+**Usage**:
+```rust
+let security_util = SecurityUtil::new();
+let master_key = security_util.load_master_key()?;
+let password = "admin_password";
+
+let encrypted = security_util.encrypt_to_base64_string(
+    password.as_bytes(),
+    &master_key
+)?;
+
+// Store encrypted in configuration file
+println!("Encrypted password: {}", encrypted);
+```
+
+#### decrypt_from_base64_string
+
+**Signature**:
+```rust
+pub fn decrypt_from_base64_string(
+    &self,
+    cipher_text: &str,
+    master_key: &[u8],
+) -> anyhow::Result<Vec<u8>>
+```
+
+**Description**: Decrypts a Base64-encoded ciphertext string back to plaintext.
+
+**Parameters**:
+- `cipher_text`: Base64-encoded string from `encrypt_to_base64_string()`
+- `master_key`: Same master key used for encryption
+
+**Returns**: Decrypted plaintext as bytes
+
+**Usage**:
+```rust
+let security_util = SecurityUtil::new();
+let master_key = security_util.load_master_key()?;
+let encrypted = "base64_encoded_ciphertext_here";
+
+let decrypted = security_util.decrypt_from_base64_string(
+    encrypted,
+    &master_key
+)?;
+
+let password = String::from_utf8(decrypted)?;
+println!("Decrypted password: {}", password);
+```
+
+**Error conditions**:
+- Ciphertext exceeds maximum length (1 MB)
+- Invalid Base64 encoding
+- Insufficient bytes (less than nonce + salt length)
+- Decryption failure (wrong key or corrupted data)
+
+#### Low-level Encryption Functions
+
+**encrypt_text**:
+```rust
+pub fn encrypt_text(
+    plaintext: &[u8],
+    master_key: &[u8],
+) -> anyhow::Result<(Vec<u8>, [u8; NONCE_LEN], [u8; SALT_LEN])>
+```
+
+Returns raw ciphertext, nonce, and salt separately. Used internally by `encrypt_to_base64_string()`.
+
+**decrypt_text**:
+```rust
+pub fn decrypt_text(
+    ciphertext: &[u8],
+    master_key: &[u8],
+    nonce_bytes: &[u8],
+    salt: &[u8],
+) -> anyhow::Result<Vec<u8>>
+```
+
+Decrypts raw ciphertext with provided nonce and salt. Used internally by `decrypt_from_base64_string()`.
+
+### Key Derivation
+
+The security module uses **scrypt** for key derivation, which is designed to be computationally expensive to resist brute-force attacks.
+
+**Parameters**:
+- Algorithm: scrypt
+- Parameters: `Params::recommended()` (currently N=32768, r=8, p=1)
+- Output: 32 bytes (256 bits)
+
+**Process**:
+```rust
+fn derive_key(master_key: &[u8], salt: &[u8]) -> anyhow::Result<[u8; 32]> {
+    let params = Params::recommended();
+    let mut derived_key = [0u8; 32];
+    scrypt(master_key, salt, &params, &mut derived_key)?;
+    Ok(derived_key)
+}
+```
+
+**Security considerations**:
+- Random salt is generated for each encryption operation
+- Salt is stored alongside ciphertext (not secret)
+- Derived key is automatically zeroed after use using `Zeroizing`
+
+### SCRAM-SHA-256 Authentication
+
+SCRAM-SHA-256 (Salted Challenge Response Authentication Mechanism) is used for authenticating with the pgmoneta server. It provides:
+
+- **Password protection**: Password is never sent over the network
+- **Mutual authentication**: Both client and server prove knowledge of password
+- **Replay attack protection**: Uses nonces to prevent replay attacks
+
+#### connect_to_server
+
+**Signature**:
+```rust
+pub async fn connect_to_server(
+    host: &str,
+    port: i32,
+    username: &str,
+    password: &str,
+) -> anyhow::Result<TcpStream>
+```
+
+**Description**: Establishes an authenticated TCP connection to the pgmoneta server using SCRAM-SHA-256.
+
+**Parameters**:
+- `host`: pgmoneta server hostname or IP address
+- `port`: pgmoneta server port
+- `username`: Admin username
+- `password`: Admin password (plaintext, will be hashed)
+
+**Returns**: Authenticated `TcpStream` ready for communication
+
+**Authentication flow**:
+
+1. **TCP connection**: Establish TCP connection to server
+2. **Startup message**: Send startup message with username and database
+3. **Server challenge**: Receive SASL authentication methods
+4. **Client first**: Send SCRAM-SHA-256 client-first message
+5. **Server first**: Receive server-first message with salt and iteration count
+6. **Client final**: Send client-final message with proof
+7. **Server final**: Receive server-final message with server proof
+8. **Auth success**: Receive authentication success confirmation
+
+**Usage**:
+```rust
+let stream = SecurityUtil::connect_to_server(
+    "localhost",
+    2345,
+    "admin",
+    "admin_password"
+).await?;
+
+// Use stream for communication with pgmoneta
+```
+
+**Error conditions**:
+- Cannot connect to server (network error)
+- Server does not support SCRAM-SHA-256
+- Invalid username or password
+- Authentication protocol error
+- Unexpected server response
+
+**Protocol details**:
+
+**Startup message format**:
+```
+Length (4 bytes) | Magic (4 bytes) | Parameters (null-terminated strings)
+```
+
+**Parameters**:
+- `user`: Username
+- `database`: "admin"
+- `application_name`: "pgmoneta"
+
+**Message types**:
+- `R`: Authentication request/response
+- `p`: Password message (SASL)
+- `E`: Error message
+
+**Authentication types**:
+- `0`: AUTH_OK (authentication successful)
+- `10`: AUTH_SASL (SASL authentication required)
+- `11`: AUTH_SASL_CONTINUE (continue SASL authentication)
+- `12`: AUTH_SASL_FINAL (final SASL message)
+
+### Password Generation
+
+#### generate_password
+
+**Signature**:
+```rust
+pub fn generate_password(&self, length: usize) -> anyhow::Result<String>
+```
+
+**Description**: Generates a cryptographically secure random password of specified length.
+
+**Parameters**:
+- `length`: Desired password length
+
+**Returns**: Random password string
+
+**Character set**:
+- Uppercase letters: A-Z
+- Lowercase letters: a-z
+- Digits: 0-9
+- Special characters: `!@$%^&*()-_=+[{]}\|:'",<.>/?`
+
+**Usage**:
+```rust
+let security_util = SecurityUtil::new();
+
+// Generate 64-character password
+let password = security_util.generate_password(64)?;
+println!("Generated password: {}", password);
+
+// Generate 32-character password
+let short_password = security_util.generate_password(32)?;
+```
+
+**Security features**:
+- Uses `OsRng` (operating system random number generator)
+- Cryptographically secure randomness
+- Random bytes are zeroed after use
+- Uniform distribution across character set
+
+**Best practices**:
+- Use at least 32 characters for admin passwords
+- Use 64 characters for master keys
+- Store generated passwords securely (password manager)
+
+### Base64 Encoding
+
+#### base64_encode
+
+**Signature**:
+```rust
+pub fn base64_encode(&self, bytes: &[u8]) -> anyhow::Result<String>
+```
+
+**Description**: Encodes binary data to Base64 string using standard alphabet with padding.
+
+**Usage**:
+```rust
+let security_util = SecurityUtil::new();
+let data = b"Hello, World!";
+let encoded = security_util.base64_encode(data)?;
+println!("Encoded: {}", encoded);
+```
+
+#### base64_decode
+
+**Signature**:
+```rust
+pub fn base64_decode(&self, text: &str) -> anyhow::Result<Vec<u8>>
+```
+
+**Description**: Decodes Base64 string back to binary data.
+
+**Usage**:
+```rust
+let security_util = SecurityUtil::new();
+let encoded = "SGVsbG8sIFdvcmxkIQ==";
+let decoded = security_util.base64_decode(encoded)?;
+println!("Decoded: {}", String::from_utf8(decoded)?);
+```
+
+### Memory Safety
+
+The security module uses Rust's `zeroize` crate to ensure sensitive data is securely erased from memory:
+
+**Zeroizing types**:
+- `Zeroizing<Vec<u8>>`: Automatically zeros vector contents when dropped
+- Used for master keys, derived keys, and passwords
+
+**Example**:
+```rust
+{
+    let master_key = security_util.load_master_key()?;
+    // Use master_key...
+} // master_key is automatically zeroed here
+```
+
+**Manual zeroing**:
+```rust
+use zeroize::Zeroize;
+
+let mut sensitive_data = vec![1, 2, 3, 4];
+// Use sensitive_data...
+sensitive_data.zeroize(); // Explicitly zero the data
+```
+
+### Security Best Practices
+
+#### Master Key Management
+
+1. **Generation**: Use `generate_password(32)` or better to create master key
+2. **Storage**: Store in `~/.pgmoneta-mcp/master.key` with 0600 permissions
+3. **Backup**: Keep secure offline backup of master key
+4. **Rotation**: Rotate master key periodically and re-encrypt all passwords
+5. **Never commit**: Never commit master key to version control
+
+#### Password Management
+
+1. **Strong passwords**: Use at least 32 characters for admin passwords
+2. **Unique passwords**: Use different passwords for each admin user
+3. **Encryption**: Always encrypt passwords before storing in configuration
+4. **No plaintext**: Never store passwords in plaintext
+5. **Secure transmission**: Use SCRAM-SHA-256 for authentication
+
+#### File Permissions
+
+On Unix systems, ensure proper file permissions:
+
+```bash
+# Master key file
+chmod 600 ~/.pgmoneta-mcp/master.key
+
+# User configuration file (contains encrypted passwords)
+chmod 600 /path/to/pgmoneta-mcp-users.conf
+
+# Server configuration file (contains connection details)
+chmod 600 /path/to/pgmoneta-mcp.conf
+```
+
+#### Network Security
+
+1. **TLS/SSL**: Consider using TLS for pgmoneta connections in production
+2. **Firewall**: Restrict access to pgmoneta port (typically 2345)
+3. **Authentication**: Always use SCRAM-SHA-256 (never trust authentication)
+4. **Monitoring**: Monitor authentication failures and suspicious activity
+
+### Testing
+
+The security module includes comprehensive unit tests:
+
+**Test coverage**:
+- Base64 encoding/decoding
+- Encryption/decryption round-trip
+- Password generation (length and character set)
+- Master key operations
+
+**Running tests**:
+```bash
+cargo test security
+```
+
+**Example test**:
+```rust
+#[test]
+fn test_encrypt_decrypt() {
+    let sutil = SecurityUtil::new();
+    let master_key = "test_master_key_!@#$~<>?/".as_bytes();
+    let text = "test_text_123_!@#$~<>?/";
+    
+    let encrypted = sutil
+        .encrypt_to_base64_string(text.as_bytes(), master_key)
+        .expect("Encryption should succeed");
+    
+    let decrypted = sutil
+        .decrypt_from_base64_string(&encrypted, master_key)
+        .expect("Decryption should succeed");
+    
+    assert_eq!(decrypted, text.as_bytes());
+}
+```
+
+### Error Handling
+
+All security functions return `anyhow::Result<T>` for comprehensive error handling:
+
+**Common errors**:
+- `"Unable to find home path"`: Home directory cannot be determined
+- `"Cipher text is too large"`: Encrypted data exceeds 1 MB limit
+- `"Not enough bytes to decrypt the text"`: Corrupted ciphertext
+- `"AES encryption failed"`: Encryption operation failed
+- `"AES decryption failed"`: Decryption failed (wrong key or corrupted data)
+- `"Invalid message length"`: Protocol error during authentication
+- `"Server does not offer SCRAM-SHA-256"`: Server doesn't support SCRAM
+- `"Authentication failed"`: Invalid username or password
+
+**Error handling example**:
+```rust
+match security_util.decrypt_from_base64_string(&encrypted, &master_key) {
+    Ok(decrypted) => {
+        let password = String::from_utf8(decrypted)?;
+        println!("Password: {}", password);
+    }
+    Err(e) => {
+        eprintln!("Decryption failed: {}", e);
+        // Handle error (wrong master key, corrupted data, etc.)
+    }
+}
+```
+
+### Constants
+
+**Cryptographic constants**:
+```rust
+const NONCE_LEN: usize = 12;           // AES-GCM nonce length
+const SALT_LEN: usize = 16;            // scrypt salt length
+const MAX_CIPHERTEXT_B64_LEN: usize = 1024 * 1024;  // Max encrypted data size
+```
+
+**Protocol constants**:
+```rust
+const MAGIC: i32 = 196608;             // PostgreSQL protocol magic number
+const AUTH_OK: i32 = 0;                // Authentication successful
+const AUTH_SASL: i32 = 10;             // SASL authentication required
+const AUTH_SASL_CONTINUE: i32 = 11;    // Continue SASL handshake
+const AUTH_SASL_FINAL: i32 = 12;       // Final SASL message
+const MAX_PG_MESSAGE_LEN: usize = 64 * 1024;  // Max PostgreSQL message size
+```
+
+### References
+
+- [AES-GCM](https://en.wikipedia.org/wiki/Galois/Counter_Mode)
+- [scrypt](https://en.wikipedia.org/wiki/Scrypt)
+- [SCRAM-SHA-256 RFC 7677](https://datatracker.ietf.org/doc/html/rfc7677)
+- [PostgreSQL SCRAM Authentication](https://www.postgresql.org/docs/current/sasl-authentication.html)
+- [Rust zeroize crate](https://docs.rs/zeroize/)
+- [Base64 RFC 4648](https://datatracker.ietf.org/doc/html/rfc4648)

--- a/doc/manual/en/81-client-api.md
+++ b/doc/manual/en/81-client-api.md
@@ -1,0 +1,797 @@
+\newpage
+
+## Client API
+
+### Overview
+
+The **Client API** provides low-level communication with the pgmoneta server. It handles TCP connection management, request serialization, response parsing, and the complete request/response lifecycle.
+
+The client module is defined and implemented in `src/client.rs` and `src/handler/info.rs`.
+
+**Key responsibilities**:
+- Build and serialize request headers and payloads
+- Establish authenticated TCP connections
+- Write requests to TCP stream
+- Read and parse responses from TCP stream
+- Forward requests to pgmoneta server
+
+### Architecture
+
+```
+┌─────────────────────────────────────────┐
+│         PgmonetaClient                  │
+├─────────────────────────────────────────┤
+│  Connection Management                  │
+│  - connect_to_server()                  │
+│  - Uses SecurityUtil for auth           │
+│                                         │
+│  Request Building                       │
+│  - build_request_header()               │
+│  - PgmonetaRequest<R> wrapper           │
+│                                         │
+│  Communication                          │
+│  - write_request()                      │
+│  - read_response()                      │
+│  - forward_request()                    │
+└─────────────────────────────────────────┘
+```
+
+### PgmonetaClient Structure
+
+The `PgmonetaClient` is a zero-sized type that provides static methods for communicating with the pgmoneta server:
+
+```rust
+pub struct PgmonetaClient;
+```
+
+All methods are associated functions (not instance methods), so no instance creation is needed.
+
+### Request Structure
+
+#### RequestHeader
+
+The `RequestHeader` contains metadata about the request:
+
+```rust
+struct RequestHeader {
+    command: u32,           // Command code (e.g., Command::INFO)
+    client_version: String, // MCP client version
+    output_format: u8,      // Response format (JSON)
+    timestamp: String,      // Request timestamp (YYYYMMDDHHmmss)
+    compression: u8,        // Compression type (NONE)
+    encryption: u8,         // Encryption type (NONE)
+}
+```
+
+**Field details**:
+
+- **command**: Numeric command code from `Command` constants
+  - `Command::INFO` (1): Get backup information
+  - `Command::LIST_BACKUP` (2): List backups
+  - See `src/constant.rs` for complete list
+
+- **client_version**: Version string (e.g., "0.2.0")
+  - Defined in `constant::CLIENT_VERSION`
+
+- **output_format**: Response format
+  - `Format::JSON` (1): JSON format (default)
+  - `Format::TEXT` (2): Plain text format
+
+- **timestamp**: Local timestamp when request was created
+  - Format: `YYYYMMDDHHmmss`
+  - Example: `"20260304123045"`
+
+- **compression**: Compression algorithm
+  - `Compression::NONE` (0): No compression (default)
+  - `Compression::GZIP` (1): gzip compression
+  - `Compression::ZSTD` (2): zstd compression
+  - `Compression::LZ4` (3): lz4 compression
+  - `Compression::BZIP2` (4): bzip2 compression
+
+- **encryption**: Encryption algorithm
+  - `Encryption::NONE` (0): No encryption (default)
+  - `Encryption::AES_256_CBC` (1): AES-256-CBC
+  - `Encryption::AES_192_CBC` (2): AES-192-CBC
+  - `Encryption::AES_128_CBC` (3): AES-128-CBC
+  - `Encryption::AES_256_CTR` (4): AES-256-CTR
+  - `Encryption::AES_192_CTR` (5): AES-192-CTR
+  - `Encryption::AES_128_CTR` (6): AES-128-CTR
+
+#### PgmonetaRequest
+
+The `PgmonetaRequest` wraps the header and request payload:
+
+```rust
+struct PgmonetaRequest<R>
+where
+    R: Serialize + Clone + Debug,
+{
+    header: RequestHeader,
+    request: R,
+}
+```
+
+**Generic parameter**:
+- `R`: Request payload type (must be serializable to JSON)
+
+**Serialized JSON format**:
+```json
+{
+  "Header": {
+    "Command": 1,
+    "ClientVersion": "0.2.0",
+    "Output": 1,
+    "Timestamp": "20260304123045",
+    "Compression": 0,
+    "Encryption": 0
+  },
+  "Request": {
+    // Request-specific fields
+  }
+}
+```
+
+### Request Payloads
+
+#### InfoRequest
+
+Request structure for getting backup information:
+
+```rust
+pub struct InfoRequest {
+    pub server: String,
+    pub backup_id: String,
+}
+```
+
+**Fields**:
+- `server`: Server name as configured in pgmoneta
+- `backup_id`: Backup identifier
+  - Backup label (e.g., "20260304123045")
+  - "newest" or "latest": Most recent backup
+  - "oldest": Oldest backup
+
+**Example**:
+```rust
+let request = InfoRequest {
+    server: "primary".to_string(),
+    backup_id: "latest".to_string(),
+};
+```
+
+**Serialized JSON**:
+```json
+{
+  "Server": "primary",
+  "BackupId": "latest"
+}
+```
+
+#### ListBackupsRequest
+
+Request structure for listing backups:
+
+```rust
+pub struct ListBackupsRequest {
+    pub server: String,
+    pub sort_order: Option<String>,
+}
+```
+
+**Fields**:
+- `server`: Server name as configured in pgmoneta
+- `sort_order`: Optional sort order
+  - `"asc"`: Ascending order (oldest first)
+  - `"desc"`: Descending order (newest first)
+  - `None`: Default to ascending
+
+**Example**:
+```rust
+let request = ListBackupsRequest {
+    server: "primary".to_string(),
+    sort_order: Some("desc".to_string()),
+};
+```
+
+**Serialized JSON**:
+```json
+{
+  "Server": "primary",
+  "SortOrder": "desc"
+}
+```
+
+### Core Methods
+
+#### build_request_header
+
+**Signature**:
+```rust
+fn build_request_header(command: u32) -> RequestHeader
+```
+
+**Description**: Constructs a standard request header for the given command.
+
+**Parameters**:
+- `command`: Command code (e.g., `Command::INFO`)
+
+**Returns**: Populated `RequestHeader` with current timestamp
+
+**Default values**:
+- `client_version`: From `CLIENT_VERSION` constant
+- `output_format`: `Format::JSON`
+- `compression`: `Compression::NONE`
+- `encryption`: `Encryption::NONE`
+
+**Usage** (internal):
+```rust
+let header = Self::build_request_header(Command::INFO);
+```
+
+**Timestamp format**:
+```rust
+let timestamp = Local::now().format("%Y%m%d%H%M%S").to_string();
+// Example: "20260304123045"
+```
+
+#### connect_to_server
+
+**Signature**:
+```rust
+async fn connect_to_server(username: &str) -> anyhow::Result<TcpStream>
+```
+
+**Description**: Establishes an authenticated TCP connection to the pgmoneta server.
+
+**Process**:
+1. Load configuration to get host and port
+2. Look up username in admin configuration
+3. Load master key from filesystem
+4. Decrypt admin password using master key
+5. Connect to server using SCRAM-SHA-256 authentication
+
+**Parameters**:
+- `username`: Admin username from MCP request
+
+**Returns**: Authenticated `TcpStream` ready for communication
+
+**Usage** (internal):
+```rust
+let stream = Self::connect_to_server("admin").await?;
+```
+
+**Error conditions**:
+- Configuration not initialized
+- Username not found in admin configuration
+- Master key cannot be loaded
+- Password decryption fails
+- SCRAM-SHA-256 authentication fails
+
+**Dependencies**:
+- `CONFIG`: Global configuration (must be initialized)
+- `SecurityUtil::load_master_key()`: Load master key
+- `SecurityUtil::decrypt_from_base64_string()`: Decrypt password
+- `SecurityUtil::connect_to_server()`: SCRAM authentication
+
+#### write_request
+
+**Signature**:
+```rust
+async fn write_request(request_str: &str, stream: &mut TcpStream) -> anyhow::Result<()>
+```
+
+**Description**: Writes a serialized JSON request to the TCP stream.
+
+**Protocol**:
+1. Write compression flag (1 byte)
+2. Write encryption flag (1 byte)
+3. Write payload length (4 bytes, i32)
+4. Write payload bytes
+
+**Parameters**:
+- `request_str`: JSON-serialized request string
+- `stream`: Mutable reference to TCP stream
+
+**Wire format**:
+```
++-------------+-------------+----------------+------------------+
+| Compression | Encryption  | Length (i32)   | Payload (JSON)   |
+| (1 byte)    | (1 byte)    | (4 bytes)      | (variable)       |
++-------------+-------------+----------------+------------------+
+```
+
+**Usage** (internal):
+```rust
+let request_str = serde_json::to_string(&request)?;
+Self::write_request(&request_str, &mut stream).await?;
+```
+
+**Example wire data**:
+```
+00                    // Compression: NONE
+00                    // Encryption: NONE
+00 00 00 5A           // Length: 90 bytes
+7B 22 48 65 61 64...  // JSON payload: {"Header":...}
+```
+
+#### read_response
+
+**Signature**:
+```rust
+async fn read_response(stream: &mut TcpStream) -> anyhow::Result<String>
+```
+
+**Description**: Reads the response payload from the TCP stream.
+
+**Protocol**:
+1. Read compression flag (1 byte)
+2. Read encryption flag (1 byte)
+3. Read payload length (4 bytes, u32)
+4. Read exact number of payload bytes
+
+**Parameters**:
+- `stream`: Mutable reference to TCP stream
+
+**Returns**: JSON response string
+
+**Wire format**:
+```
++-------------+-------------+----------------+------------------+
+| Compression | Encryption  | Length (u32)   | Payload (JSON)   |
+| (1 byte)    | (1 byte)    | (4 bytes)      | (variable)       |
++-------------+-------------+----------------+------------------+
+```
+
+**Usage** (internal):
+```rust
+let response_str = Self::read_response(&mut stream).await?;
+```
+
+**Example response**:
+```json
+{
+  "Outcome": "Success",
+  "BackupInfo": {
+    "Server": "primary",
+    "Label": "20260304123045",
+    ...
+  }
+}
+```
+
+**Error conditions**:
+- TCP read error
+- Invalid payload length
+- Incomplete payload read
+
+#### forward_request
+
+**Signature**:
+```rust
+async fn forward_request<R>(
+    username: &str,
+    command: u32,
+    request: R
+) -> anyhow::Result<String>
+where
+    R: Serialize + Clone + Debug,
+```
+
+**Description**: End-to-end request forwarding to pgmoneta server.
+
+**Process**:
+1. Connect to server (with authentication)
+2. Build request header
+3. Wrap request with header
+4. Serialize to JSON
+5. Write request to stream
+6. Read response from stream
+7. Return response string
+
+**Parameters**:
+- `username`: Admin username for authentication
+- `command`: Command code (e.g., `Command::INFO`)
+- `request`: Request payload (must be serializable)
+
+**Returns**: JSON response string from pgmoneta server
+
+**Usage**:
+```rust
+let request = InfoRequest {
+    server: "primary".to_string(),
+    backup_id: "latest".to_string(),
+};
+
+let response = PgmonetaClient::forward_request(
+    "admin",
+    Command::INFO,
+    request
+).await?;
+
+println!("Response: {}", response);
+```
+
+**Logging**:
+```rust
+tracing::info!(username = username, "Connected to server");
+tracing::debug!(username = username, request = ?request, "Sent request to server");
+```
+
+**Error handling**:
+```rust
+match PgmonetaClient::forward_request("admin", Command::INFO, request).await {
+    Ok(response) => {
+        // Parse and process response
+        let result: serde_json::Value = serde_json::from_str(&response)?;
+        println!("Result: {}", result);
+    }
+    Err(e) => {
+        eprintln!("Request failed: {}", e);
+    }
+}
+```
+
+### Usage Examples
+
+#### Getting Backup Information
+
+```rust
+use pgmoneta_mcp::client::PgmonetaClient;
+use pgmoneta_mcp::handler::info::InfoRequest;
+use pgmoneta_mcp::constant::Command;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    // Create request
+    let request = InfoRequest {
+        server: "primary".to_string(),
+        backup_id: "latest".to_string(),
+    };
+
+    // Forward request to pgmoneta server
+    let response = PgmonetaClient::forward_request(
+        "admin",
+        Command::INFO,
+        request
+    ).await?;
+
+    // Parse response
+    let result: serde_json::Value = serde_json::from_str(&response)?;
+    
+    // Extract backup info
+    if let Some(backup_info) = result.get("BackupInfo") {
+        println!("Backup Label: {}", backup_info["Label"]);
+        println!("Backup Size: {}", backup_info["BackupSize"]);
+        println!("Compression: {}", backup_info["Compression"]);
+    }
+
+    Ok(())
+}
+```
+
+#### Listing Backups
+
+```rust
+use pgmoneta_mcp::client::PgmonetaClient;
+use pgmoneta_mcp::handler::info::ListBackupsRequest;
+use pgmoneta_mcp::constant::Command;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    // Create request
+    let request = ListBackupsRequest {
+        server: "primary".to_string(),
+        sort_order: Some("desc".to_string()),
+    };
+
+    // Forward request to pgmoneta server
+    let response = PgmonetaClient::forward_request(
+        "admin",
+        Command::LIST_BACKUP,
+        request
+    ).await?;
+
+    // Parse response
+    let result: serde_json::Value = serde_json::from_str(&response)?;
+    
+    // Extract backups list
+    if let Some(backups) = result.get("Backups").and_then(|v| v.as_array()) {
+        for backup in backups {
+            println!("Label: {}", backup["Label"]);
+            println!("Size: {}", backup["BackupSize"]);
+            println!("---");
+        }
+    }
+
+    Ok(())
+}
+```
+
+### Response Format
+
+All responses from pgmoneta follow a standard format:
+
+**Success response**:
+```json
+{
+  "Outcome": "Success",
+  "BackupInfo": {
+    // Response-specific data
+  }
+}
+```
+
+**Error response**:
+```json
+{
+  "Outcome": "Error",
+  "Error": 1,
+  "ErrorMessage": "Backup not found"
+}
+```
+
+**Response fields**:
+- `Outcome`: "Success" or "Error"
+- `Error`: Error code (if outcome is "Error")
+- `ErrorMessage`: Human-readable error message (if outcome is "Error")
+- Additional fields: Response-specific data (varies by command)
+
+### Error Handling
+
+The client API uses `anyhow::Result<T>` for error handling:
+
+**Common errors**:
+- **Connection errors**: Cannot connect to pgmoneta server
+  - Check host and port in configuration
+  - Ensure pgmoneta server is running
+  - Check firewall rules
+
+- **Authentication errors**: SCRAM-SHA-256 authentication fails
+  - Verify username exists in admin configuration
+  - Verify password is correct
+  - Check master key is correct
+
+- **Protocol errors**: Invalid message format
+  - Ensure pgmoneta server version is compatible
+  - Check for network corruption
+
+- **Serialization errors**: Cannot serialize request or parse response
+  - Verify request structure matches expected format
+  - Check response is valid JSON
+
+**Error handling example**:
+```rust
+match PgmonetaClient::forward_request("admin", Command::INFO, request).await {
+    Ok(response) => {
+        // Success - process response
+        println!("Response: {}", response);
+    }
+    Err(e) => {
+        // Error - handle appropriately
+        if e.to_string().contains("Authentication failed") {
+            eprintln!("Authentication error: Check username and password");
+        } else if e.to_string().contains("Connection refused") {
+            eprintln!("Connection error: Is pgmoneta server running?");
+        } else {
+            eprintln!("Request failed: {}", e);
+        }
+    }
+}
+```
+
+### Configuration Requirements
+
+The client API requires the global configuration to be initialized:
+
+**Configuration structure**:
+```rust
+pub struct Configuration {
+    pub pgmoneta: PgmonetaConfiguration,
+    pub admins: HashMap<String, String>,
+}
+
+pub struct PgmonetaConfiguration {
+    pub host: String,
+    pub port: i32,
+}
+```
+
+**Initialization**:
+```rust
+use pgmoneta_mcp::configuration::{load_configuration, CONFIG};
+
+// Load configuration files
+let config = load_configuration(
+    "pgmoneta-mcp.conf",
+    "pgmoneta-mcp-users.conf"
+)?;
+
+// Initialize global configuration
+CONFIG.set(config).expect("Configuration already initialized");
+```
+
+**Configuration files**:
+
+`pgmoneta-mcp.conf`:
+```ini
+[pgmoneta]
+host = localhost
+port = 2345
+```
+
+`pgmoneta-mcp-users.conf`:
+```ini
+[admin]
+password = <encrypted_password_base64>
+```
+
+### Performance Considerations
+
+#### Connection Management
+
+- **New connection per request**: Each `forward_request()` call establishes a new TCP connection
+- **Authentication overhead**: SCRAM-SHA-256 handshake adds latency (~10-50ms)
+- **Connection pooling**: Consider implementing connection pooling for high-frequency requests
+
+**Potential optimization**:
+```rust
+// Future enhancement: Connection pool
+pub struct ConnectionPool {
+    connections: Vec<TcpStream>,
+    max_size: usize,
+}
+
+impl ConnectionPool {
+    pub async fn get_connection(&mut self) -> anyhow::Result<TcpStream> {
+        // Reuse existing connection or create new one
+    }
+}
+```
+
+#### Request Serialization
+
+- **JSON serialization**: Uses `serde_json` for efficient serialization
+- **Small payloads**: Most requests are < 1 KB
+- **No compression**: Currently no compression is used (could be added)
+
+#### Response Parsing
+
+- **Streaming**: Response is read in one operation
+- **Memory efficient**: No intermediate buffering
+- **JSON parsing**: Deferred to caller (allows streaming processing)
+
+### Security Considerations
+
+#### Authentication
+
+- **SCRAM-SHA-256**: Strong authentication mechanism
+- **No password in logs**: Passwords are never logged
+- **Encrypted storage**: Passwords encrypted at rest in configuration
+
+#### Network Security
+
+- **Plaintext protocol**: Currently no TLS/SSL support
+- **Local network**: Designed for localhost or trusted network
+- **Firewall**: Restrict access to pgmoneta port
+
+**Future enhancement**:
+```rust
+// Add TLS support
+use tokio_native_tls::TlsConnector;
+
+pub async fn connect_to_server_tls(
+    host: &str,
+    port: i32,
+    username: &str,
+    password: &str,
+) -> anyhow::Result<TlsStream<TcpStream>> {
+    // Establish TLS connection
+}
+```
+
+#### Data Validation
+
+- **Input validation**: Request fields are validated before sending
+- **Response validation**: Response format is checked before parsing
+- **Error handling**: All errors are properly propagated
+
+### Debugging
+
+Enable debug logging to see detailed client operations:
+
+**Configuration**:
+```ini
+[log]
+level = debug
+```
+
+**Debug output**:
+```
+INFO Connected to server, username=admin
+DEBUG Sent request to server, request=PgmonetaRequest { 
+    header: RequestHeader { 
+        command: 1, 
+        client_version: "0.2.0", 
+        output_format: 1, 
+        timestamp: "20260304123045", 
+        compression: 0, 
+        encryption: 0 
+    }, 
+    request: InfoRequest { 
+        server: "primary", 
+        backup_id: "latest" 
+    } 
+}
+```
+
+**Tracing spans**:
+```rust
+use tracing::{info, debug, instrument};
+
+#[instrument(skip(stream))]
+async fn write_request(request_str: &str, stream: &mut TcpStream) -> anyhow::Result<()> {
+    debug!(length = request_str.len(), "Writing request");
+    // ... write logic
+    Ok(())
+}
+```
+
+### Testing
+
+The client module should be tested with integration tests:
+
+**Test structure**:
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_forward_request_info() {
+        // Requires running pgmoneta server
+        let request = InfoRequest {
+            server: "primary".to_string(),
+            backup_id: "latest".to_string(),
+        };
+
+        let response = PgmonetaClient::forward_request(
+            "admin",
+            Command::INFO,
+            request
+        ).await;
+
+        assert!(response.is_ok());
+    }
+}
+```
+
+**Mock server for testing**:
+```rust
+// Create mock pgmoneta server for unit tests
+pub struct MockPgmonetaServer {
+    listener: TcpListener,
+}
+
+impl MockPgmonetaServer {
+    pub async fn new() -> anyhow::Result<Self> {
+        let listener = TcpListener::bind("127.0.0.1:0").await?;
+        Ok(Self { listener })
+    }
+
+    pub async fn accept_and_respond(&self, response: &str) -> anyhow::Result<()> {
+        let (mut stream, _) = self.listener.accept().await?;
+        // Handle authentication...
+        // Read request...
+        // Write response...
+        Ok(())
+    }
+}
+```
+
+### References
+
+- [pgmoneta Protocol Documentation](https://pgmoneta.github.io/)
+- [SCRAM-SHA-256 RFC 7677](https://datatracker.ietf.org/doc/html/rfc7677)
+- [PostgreSQL Protocol](https://www.postgresql.org/docs/current/protocol.html)
+- [Tokio TCP Documentation](https://docs.rs/tokio/latest/tokio/net/struct.TcpStream.html)
+- [serde_json Documentation](https://docs.rs/serde_json/)

--- a/doc/manual/en/97-acknowledgement.md
+++ b/doc/manual/en/97-acknowledgement.md
@@ -15,6 +15,7 @@ Noor Amjad <xdjust18@gmail.com>
 Austin Senna Wijaya <austinsenna@gmail.com>
 Trevor Jacob Mathews <trevorjacobmathews@gmail.com>
 Chen Shen <scisbeloved23@gmail.com>
+Nihal Kumar <collabwithnihal@gmail.com>
 ```
 
 ## Committers

--- a/src/bin/admin.rs
+++ b/src/bin/admin.rs
@@ -14,63 +14,151 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 use anyhow::{Result, anyhow};
 use clap::{Parser, Subcommand};
-use configuration::UserConf;
-use pgmoneta_mcp::configuration;
+use pgmoneta_mcp::configuration::{self, UserConf};
 use pgmoneta_mcp::security::SecurityUtil;
 use rpassword::prompt_password;
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fs;
 use std::path::Path;
 
 #[derive(Parser, Debug)]
-#[command(name = "pgmoneta-mcp-admin", about = "Pgmoneta-mcp admin tool")]
+#[command(
+    name = "pgmoneta-mcp-admin",
+    about = "Administration utility for pgmoneta-mcp",
+    version
+)]
 struct Args {
+    /// The user configuration file
+    #[arg(short = 'f', long)]
+    file: Option<String>,
+
+    /// The user name
+    #[arg(short = 'U', long)]
+    user: Option<String>,
+
+    /// The password for the user
+    #[arg(short = 'P', long)]
+    password: Option<String>,
+
+    /// Generate a password
+    #[arg(short = 'g', long)]
+    generate: bool,
+
+    /// Password length (default: 64, ignored when --generate is false)
+    #[arg(short = 'l', long, default_value = "64")]
+    length: usize,
+
+    /// Output format
+    #[arg(short = 'F', long, value_enum, default_value = "text")]
+    format: OutputFormat,
+
     #[command(subcommand)]
     command: Commands,
 }
 
 #[derive(Subcommand, Debug)]
 enum Commands {
-    /// User related operations
+    /// Create or update the master key
+    MasterKey,
+    /// Manage a specific user
     User {
         #[command(subcommand)]
         action: UserAction,
-        /// The admin user
-        #[arg(short = 'U', long)]
-        user: String,
-        /// The user configuration file
-        #[arg(short = 'f', long)]
-        file: String,
     },
-    MasterKey,
 }
 
 #[derive(Subcommand, Debug)]
 enum UserAction {
-    /// Add a new user to configuration file, the file will be automatically created if not exist.
-    /// If the user exists, new password will be set to the existing user.
-    Add {
-        /// The admin user password
-        #[arg(short = 'P', long)]
-        password: String,
-    },
+    /// Add a new user to configuration file
+    Add,
+    /// Remove an existing user
+    Del,
+    /// Change the password for an existing user
+    Edit,
+    /// List all available users
+    Ls,
+}
+
+#[derive(Debug, Clone, Copy, Default, clap::ValueEnum)]
+pub enum OutputFormat {
+    #[default]
+    Text,
+    Json,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct AdminResponse {
+    command: String,
+    outcome: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    users: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    generated_password: Option<String>,
 }
 fn main() -> Result<()> {
     let args = Args::parse();
+
     match args.command {
-        Commands::User { action, user, file } => match action {
-            UserAction::Add { password } => User::set_user(&file, &user, &password)?,
-        },
         Commands::MasterKey => {
-            MasterKey::set_master_key()?;
+            MasterKey::set_master_key(
+                args.password.as_deref(),
+                args.generate,
+                args.length,
+                args.format,
+            )?;
+        }
+        Commands::User { action } => {
+            let file = args
+                .file
+                .as_ref()
+                .ok_or_else(|| anyhow!("Missing required argument: -f, --file <FILE>"))?;
+
+            match action {
+                UserAction::Add => {
+                    let user = args
+                        .user
+                        .as_ref()
+                        .ok_or_else(|| anyhow!("Missing required argument: -U, --user <USER>"))?;
+                    let password = User::get_or_generate_password(
+                        args.password.as_deref(),
+                        args.generate,
+                        args.length,
+                    )?;
+                    User::add_user(file, user, &password, args.format)?;
+                }
+                UserAction::Del => {
+                    let user = args
+                        .user
+                        .as_ref()
+                        .ok_or_else(|| anyhow!("Missing required argument: -U, --user <USER>"))?;
+                    User::remove_user(file, user, args.format)?;
+                }
+                UserAction::Edit => {
+                    let user = args
+                        .user
+                        .as_ref()
+                        .ok_or_else(|| anyhow!("Missing required argument: -U, --user <USER>"))?;
+                    let password = User::get_or_generate_password(
+                        args.password.as_deref(),
+                        args.generate,
+                        args.length,
+                    )?;
+                    User::edit_user(file, user, &password, args.format)?;
+                }
+                UserAction::Ls => {
+                    User::list_users(file, args.format)?;
+                }
+            }
         }
     }
+
     Ok(())
 }
 
 struct User;
 impl User {
-    pub fn set_user(file: &str, user: &str, password: &str) -> Result<()> {
+    pub fn add_user(file: &str, user: &str, password: &str, format: OutputFormat) -> Result<()> {
         let path = Path::new(file);
         let sutil = SecurityUtil::new();
         let mut conf: UserConf;
@@ -90,6 +178,9 @@ impl User {
         } else {
             conf = configuration::load_user_configuration(file)?;
             if let Some(user_conf) = conf.get_mut("admins") {
+                if user_conf.contains_key(user) {
+                    return Err(anyhow!("User '{}' already exists", user));
+                }
                 user_conf.insert(user.to_string(), password_str);
             } else {
                 return Err(anyhow!("Unable to find admins in user configuration"));
@@ -103,22 +194,320 @@ impl User {
         let conf_str = serde_ini::to_string(&conf)?;
         fs::write(file, &conf_str)?;
 
+        Self::print_response(
+            format,
+            AdminResponse {
+                command: "user add".to_string(),
+                outcome: "success".to_string(),
+                users: Some(vec![user.to_string()]),
+                generated_password: None,
+            },
+        );
+
         Ok(())
+    }
+
+    pub fn remove_user(file: &str, user: &str, format: OutputFormat) -> Result<()> {
+        let path = Path::new(file);
+
+        if !path.exists() {
+            return Err(anyhow!("User file '{}' does not exist", file));
+        }
+
+        let mut conf = configuration::load_user_configuration(file)?;
+
+        if let Some(user_conf) = conf.get_mut("admins") {
+            if user_conf.remove(user).is_none() {
+                return Err(anyhow!("User '{}' not found", user));
+            }
+        } else {
+            return Err(anyhow!(
+                "Unable to find admins section in user configuration"
+            ));
+        }
+
+        let conf_str = serde_ini::to_string(&conf)?;
+        fs::write(file, &conf_str)?;
+
+        Self::print_response(
+            format,
+            AdminResponse {
+                command: "user del".to_string(),
+                outcome: "success".to_string(),
+                users: Some(vec![user.to_string()]),
+                generated_password: None,
+            },
+        );
+
+        Ok(())
+    }
+
+    pub fn edit_user(file: &str, user: &str, password: &str, format: OutputFormat) -> Result<()> {
+        let path = Path::new(file);
+        let sutil = SecurityUtil::new();
+
+        if !path.exists() {
+            return Err(anyhow!("User file '{}' does not exist", file));
+        }
+
+        let master_key = sutil.load_master_key().map_err(|e| {
+            anyhow!(
+                "Unable to load the master key, needed for editing user: {:?}",
+                e
+            )
+        })?;
+
+        let password_str = sutil.encrypt_to_base64_string(password.as_bytes(), &master_key[..])?;
+
+        let mut conf = configuration::load_user_configuration(file)?;
+
+        if let Some(user_conf) = conf.get_mut("admins") {
+            if user_conf.get(user).is_none() {
+                return Err(anyhow!("User '{}' not found", user));
+            }
+            user_conf.insert(user.to_string(), password_str);
+        } else {
+            return Err(anyhow!(
+                "Unable to find admins section in user configuration"
+            ));
+        }
+
+        let conf_str = serde_ini::to_string(&conf)?;
+        fs::write(file, &conf_str)?;
+
+        Self::print_response(
+            format,
+            AdminResponse {
+                command: "user edit".to_string(),
+                outcome: "success".to_string(),
+                users: Some(vec![user.to_string()]),
+                generated_password: None,
+            },
+        );
+
+        Ok(())
+    }
+
+    pub fn list_users(file: &str, format: OutputFormat) -> Result<()> {
+        let path = Path::new(file);
+
+        if !path.exists() {
+            Self::print_response(
+                format,
+                AdminResponse {
+                    command: "user ls".to_string(),
+                    outcome: "success".to_string(),
+                    users: Some(vec![]),
+                    generated_password: None,
+                },
+            );
+            return Ok(());
+        }
+
+        let conf = configuration::load_user_configuration(file)?;
+        let mut users: Vec<String> = conf
+            .get("admins")
+            .map(|user_conf| user_conf.keys().cloned().collect())
+            .unwrap_or_default();
+        users.sort_unstable();
+
+        Self::print_response(
+            format,
+            AdminResponse {
+                command: "user ls".to_string(),
+                outcome: "success".to_string(),
+                users: Some(users),
+                generated_password: None,
+            },
+        );
+
+        Ok(())
+    }
+
+    fn get_or_generate_password(
+        password: Option<&str>,
+        generate: bool,
+        length: usize,
+    ) -> Result<String> {
+        if let Some(pwd) = password {
+            return Ok(pwd.to_string());
+        }
+
+        if generate {
+            let sutil = SecurityUtil::new();
+            let generated = sutil.generate_password(length)?;
+            println!("Generated password: {}", generated);
+            return Ok(generated);
+        }
+
+        let pwd = prompt_password("Password: ")?;
+        let verify = prompt_password("Verify password: ")?;
+
+        if pwd != verify {
+            return Err(anyhow!("Passwords do not match"));
+        }
+
+        Ok(pwd)
+    }
+
+    fn print_response(format: OutputFormat, response: AdminResponse) {
+        match format {
+            OutputFormat::Json => {
+                if let Ok(json) = serde_json::to_string_pretty(&response) {
+                    println!("{}", json);
+                }
+            }
+            OutputFormat::Text => {
+                println!("Command: {}", response.command);
+                println!("Outcome: {}", response.outcome);
+                if let Some(users) = &response.users
+                    && !users.is_empty()
+                {
+                    println!("Users:");
+                    for user in users {
+                        println!("  - {}", user);
+                    }
+                }
+                if let Some(pwd) = &response.generated_password {
+                    println!("Generated password: {}", pwd);
+                }
+            }
+        }
     }
 }
 
 struct MasterKey;
 
 impl MasterKey {
-    pub fn set_master_key() -> Result<()> {
+    pub fn set_master_key(
+        password: Option<&str>,
+        generate: bool,
+        length: usize,
+        format: OutputFormat,
+    ) -> Result<()> {
         let sutil = SecurityUtil::new();
-        let master_key = prompt_password("Please enter your master key").unwrap();
-        let m = prompt_password("Please enter your master key again").unwrap();
+        let final_password: String;
 
-        if master_key != m {
-            return Err(anyhow!("Passwords do not match"));
+        let master_key = if let Some(pwd) = password {
+            final_password = pwd.to_string();
+            &final_password
+        } else if generate {
+            final_password = sutil.generate_password(length)?;
+            println!("Generated master key: {}", final_password);
+            &final_password
+        } else {
+            final_password = prompt_password("Please enter your master key: ")?;
+            let m = prompt_password("Please enter your master key again: ")?;
+
+            if final_password != m {
+                return Err(anyhow!("Passwords do not match"));
+            }
+            &final_password
+        };
+
+        sutil.write_master_key(master_key)?;
+
+        User::print_response(
+            format,
+            AdminResponse {
+                command: "master-key".to_string(),
+                outcome: "success".to_string(),
+                users: None,
+                generated_password: if generate {
+                    Some(final_password.clone())
+                } else {
+                    None
+                },
+            },
+        );
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pgmoneta_mcp::configuration::UserConf;
+    use std::fs;
+    use std::path::PathBuf;
+
+    fn get_temp_file(name: &str) -> PathBuf {
+        let mut path = std::env::temp_dir();
+        path.push(name);
+        path
+    }
+
+    #[test]
+    #[ignore]
+    fn test_add_edit_remove_user() {
+        let temp_file = get_temp_file("pgmoneta_mcp_test_users.conf");
+        let temp_file_str = temp_file.to_str().unwrap();
+
+        // Clean up before test
+        if temp_file.exists() {
+            fs::remove_file(&temp_file).unwrap();
         }
 
-        sutil.write_master_key(&master_key)
+        // Add a user
+        User::add_user(temp_file_str, "test_user", "test_pass", OutputFormat::Text).unwrap();
+
+        // Verify user was added
+        let content = fs::read_to_string(&temp_file).unwrap();
+        let users: UserConf = serde_ini::from_str(&content).unwrap();
+        assert!(users.contains_key("admins"));
+        assert!(users["admins"].contains_key("test_user"));
+        assert!(!users["admins"]["test_user"].is_empty());
+
+        // Edit the user
+        User::edit_user(temp_file_str, "test_user", "new_pass", OutputFormat::Text).unwrap();
+
+        // Verify user was edited
+        let content = fs::read_to_string(&temp_file).unwrap();
+        let users: UserConf = serde_ini::from_str(&content).unwrap();
+        let content2 = fs::read_to_string(&temp_file).unwrap();
+        let users2: UserConf = serde_ini::from_str(&content2).unwrap();
+        assert_ne!(users["admins"]["test_user"], users2["admins"]["test_user"]);
+
+        // Remove the user
+        User::remove_user(temp_file_str, "test_user", OutputFormat::Text).unwrap();
+
+        // Verify user was removed
+        let content = fs::read_to_string(&temp_file).unwrap();
+        let users: UserConf = serde_ini::from_str(&content).unwrap();
+        assert!(
+            !users
+                .get("admins")
+                .is_some_and(|a| a.contains_key("test_user"))
+        );
+
+        // Clean up after test
+        if temp_file.exists() {
+            fs::remove_file(&temp_file).unwrap();
+        }
+    }
+
+    #[test]
+    #[ignore]
+    fn test_list_users() {
+        let temp_file = get_temp_file("pgmoneta_mcp_test_users_list.conf");
+        let temp_file_str = temp_file.to_str().unwrap();
+
+        // Clean up before test
+        if temp_file.exists() {
+            fs::remove_file(&temp_file).unwrap();
+        }
+
+        User::add_user(temp_file_str, "user1", "pass1", OutputFormat::Text).unwrap();
+        User::add_user(temp_file_str, "user2", "pass2", OutputFormat::Text).unwrap();
+
+        // We can't easily capture stdout here, but we can ensure the function runs without error
+        User::list_users(temp_file_str, OutputFormat::Text).unwrap();
+        User::list_users(temp_file_str, OutputFormat::Json).unwrap();
+
+        // Clean up after test
+        if temp_file.exists() {
+            fs::remove_file(&temp_file).unwrap();
+        }
     }
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -179,3 +179,165 @@ impl PgmonetaClient {
         Self::read_response(&mut stream).await
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_build_request_header() {
+        let header = PgmonetaClient::build_request_header(Command::INFO);
+
+        assert_eq!(header.command, Command::INFO);
+        assert_eq!(header.client_version, CLIENT_VERSION);
+        assert_eq!(header.output_format, Format::JSON);
+        assert_eq!(header.compression, Compression::NONE);
+        assert_eq!(header.encryption, Encryption::NONE);
+
+        // Timestamp should be in YYYYMMDDHHmmss format (14 characters)
+        assert_eq!(header.timestamp.len(), 14);
+        assert!(header.timestamp.chars().all(|c| c.is_ascii_digit()));
+    }
+
+    #[test]
+    fn test_build_request_header_different_commands() {
+        let header1 = PgmonetaClient::build_request_header(Command::INFO);
+        let header2 = PgmonetaClient::build_request_header(Command::LIST_BACKUP);
+
+        assert_eq!(header1.command, Command::INFO);
+        assert_eq!(header2.command, Command::LIST_BACKUP);
+        assert_ne!(header1.command, header2.command);
+    }
+
+    #[test]
+    fn test_request_serialization() {
+        #[derive(Serialize, Clone, Debug)]
+        struct TestRequest {
+            field1: String,
+            field2: i32,
+        }
+
+        let test_request = TestRequest {
+            field1: "test".to_string(),
+            field2: 42,
+        };
+
+        let header = PgmonetaClient::build_request_header(Command::INFO);
+        let request = PgmonetaRequest {
+            header,
+            request: test_request,
+        };
+
+        let serialized = serde_json::to_string(&request).expect("Serialization should succeed");
+
+        // Verify JSON contains expected fields
+        assert!(serialized.contains("\"Header\""));
+        assert!(serialized.contains("\"Request\""));
+        assert!(serialized.contains("\"Command\""));
+        assert!(serialized.contains("\"ClientVersion\""));
+        assert!(serialized.contains("\"field1\""));
+        assert!(serialized.contains("\"field2\""));
+        assert!(serialized.contains("\"test\""));
+        assert!(serialized.contains("42"));
+    }
+
+    #[test]
+    fn test_request_header_serialization() {
+        let header = RequestHeader {
+            command: 1,
+            client_version: "0.2.0".to_string(),
+            output_format: Format::JSON,
+            timestamp: "20260304123045".to_string(),
+            compression: Compression::NONE,
+            encryption: Encryption::NONE,
+        };
+
+        let serialized = serde_json::to_string(&header).expect("Serialization should succeed");
+        let deserialized: serde_json::Value =
+            serde_json::from_str(&serialized).expect("Deserialization should succeed");
+
+        assert_eq!(deserialized["Command"], 1);
+        assert_eq!(deserialized["ClientVersion"], "0.2.0");
+        assert_eq!(deserialized["Output"], Format::JSON);
+        assert_eq!(deserialized["Timestamp"], "20260304123045");
+        assert_eq!(deserialized["Compression"], Compression::NONE);
+        assert_eq!(deserialized["Encryption"], Encryption::NONE);
+    }
+
+    #[tokio::test]
+    async fn test_write_request_format() {
+        // Create a mock TCP stream using a buffer
+        let mut buffer = Vec::new();
+        let request_str = r#"{"test":"data"}"#;
+
+        // Manually write what write_request would write
+        let mut temp_buf = Vec::new();
+        temp_buf.write_i32(request_str.len() as i32).await.unwrap();
+        temp_buf.write_all(request_str.as_bytes()).await.unwrap();
+
+        buffer.write_u8(Compression::NONE).await.unwrap();
+        buffer.write_u8(Encryption::NONE).await.unwrap();
+        buffer.write_all(&temp_buf).await.unwrap();
+
+        // Verify the format
+        assert_eq!(buffer[0], Compression::NONE);
+        assert_eq!(buffer[1], Encryption::NONE);
+
+        // Read length
+        let length = i32::from_be_bytes([buffer[2], buffer[3], buffer[4], buffer[5]]);
+        assert_eq!(length, request_str.len() as i32);
+
+        // Verify payload
+        let payload = String::from_utf8(buffer[6..].to_vec()).unwrap();
+        assert_eq!(payload, request_str);
+    }
+
+    #[test]
+    fn test_timestamp_format() {
+        let header = PgmonetaClient::build_request_header(Command::INFO);
+        let timestamp = &header.timestamp;
+
+        // Should be exactly 14 digits
+        assert_eq!(timestamp.len(), 14);
+
+        // Parse components
+        let year: i32 = timestamp[0..4].parse().expect("Year should be valid");
+        let month: i32 = timestamp[4..6].parse().expect("Month should be valid");
+        let day: i32 = timestamp[6..8].parse().expect("Day should be valid");
+        let hour: i32 = timestamp[8..10].parse().expect("Hour should be valid");
+        let minute: i32 = timestamp[10..12].parse().expect("Minute should be valid");
+        let second: i32 = timestamp[12..14].parse().expect("Second should be valid");
+
+        // Validate ranges
+        assert!((2020..=2100).contains(&year));
+        assert!((1..=12).contains(&month));
+        assert!((1..=31).contains(&day));
+        assert!((0..24).contains(&hour));
+        assert!((0..60).contains(&minute));
+        assert!((0..60).contains(&second));
+    }
+
+    #[test]
+    fn test_request_clone() {
+        #[derive(Serialize, Clone, Debug)]
+        struct TestRequest {
+            data: String,
+        }
+
+        let test_request = TestRequest {
+            data: "test".to_string(),
+        };
+
+        let header = PgmonetaClient::build_request_header(Command::INFO);
+        let request1 = PgmonetaRequest {
+            header: header.clone(),
+            request: test_request.clone(),
+        };
+        let request2 = request1.clone();
+
+        let serialized1 = serde_json::to_string(&request1).unwrap();
+        let serialized2 = serde_json::to_string(&request2).unwrap();
+
+        assert_eq!(serialized1, serialized2);
+    }
+}

--- a/src/security.rs
+++ b/src/security.rs
@@ -157,6 +157,30 @@ impl SecurityUtil {
             salt,
         )
     }
+
+    /// Generate a random password of the specified length.
+    /// Uses alphanumeric characters and common special characters.
+    pub fn generate_password(&self, length: usize) -> anyhow::Result<String> {
+        const CHARS: &[u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZ\
+                              abcdefghijklmnopqrstuvwxyz\
+                              0123456789\
+                              !@$%^&*()-_=+[{]}\\|:'\",<.>/?";
+
+        let mut password = vec![0u8; length];
+        let mut random_bytes = vec![0u8; length];
+
+        rand::rngs::OsRng.try_fill_bytes(&mut random_bytes)?;
+
+        for (i, byte) in random_bytes.iter().enumerate() {
+            password[i] = CHARS[*byte as usize % CHARS.len()];
+        }
+
+        // Zero out random bytes for security
+        random_bytes.zeroize();
+
+        String::from_utf8(password)
+            .map_err(|e| anyhow!("Generated password contains invalid UTF-8: {:?}", e))
+    }
 }
 
 impl SecurityUtil {
@@ -449,5 +473,225 @@ mod tests {
             .decrypt_from_base64_string(&res, master_key)
             .expect("Decryption should succeed");
         assert_eq!(decrypted_text, text.as_bytes())
+    }
+
+    #[test]
+    fn test_generate_password_default_length() {
+        let sutil = SecurityUtil::new();
+        let password = sutil
+            .generate_password(64)
+            .expect("Password generation should succeed");
+        assert_eq!(password.len(), 64);
+    }
+
+    #[test]
+    fn test_generate_password_custom_length() {
+        let sutil = SecurityUtil::new();
+        let password = sutil
+            .generate_password(32)
+            .expect("Password generation should succeed");
+        assert_eq!(password.len(), 32);
+    }
+
+    #[test]
+    fn test_generate_password_contains_valid_chars() {
+        let sutil = SecurityUtil::new();
+        let password = sutil
+            .generate_password(100)
+            .expect("Password generation should succeed");
+        // Should only contain alphanumeric and special chars from the defined set.
+        let valid_chars: std::collections::HashSet<char> =
+            "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789!@$%^&*()-_=+[{]}\\|:'\",<.>/?"
+                .chars()
+                .collect();
+        assert!(password.chars().all(|c| valid_chars.contains(&c)));
+    }
+
+    #[test]
+    fn test_encrypt_decrypt_empty_string() {
+        let sutil = SecurityUtil::new();
+        let master_key = "test_master_key".as_bytes();
+        let text = "";
+        let res = sutil
+            .encrypt_to_base64_string(text.as_bytes(), master_key)
+            .expect("Encryption should succeed");
+        let decrypted_text = sutil
+            .decrypt_from_base64_string(&res, master_key)
+            .expect("Decryption should succeed");
+        assert_eq!(decrypted_text, text.as_bytes());
+    }
+
+    #[test]
+    fn test_encrypt_decrypt_large_text() {
+        let sutil = SecurityUtil::new();
+        let master_key = "test_master_key".as_bytes();
+        let text = "a".repeat(10000);
+        let res = sutil
+            .encrypt_to_base64_string(text.as_bytes(), master_key)
+            .expect("Encryption should succeed");
+        let decrypted_text = sutil
+            .decrypt_from_base64_string(&res, master_key)
+            .expect("Decryption should succeed");
+        assert_eq!(decrypted_text, text.as_bytes());
+    }
+
+    #[test]
+    fn test_encrypt_decrypt_unicode() {
+        let sutil = SecurityUtil::new();
+        let master_key = "test_master_key".as_bytes();
+        let text = "Hello 世界 🌍 Привет";
+        let res = sutil
+            .encrypt_to_base64_string(text.as_bytes(), master_key)
+            .expect("Encryption should succeed");
+        let decrypted_text = sutil
+            .decrypt_from_base64_string(&res, master_key)
+            .expect("Decryption should succeed");
+        assert_eq!(decrypted_text, text.as_bytes());
+    }
+
+    #[test]
+    fn test_decrypt_with_wrong_key() {
+        let sutil = SecurityUtil::new();
+        let master_key1 = "correct_key".as_bytes();
+        let master_key2 = "wrong_key".as_bytes();
+        let text = "secret_data";
+        let encrypted = sutil
+            .encrypt_to_base64_string(text.as_bytes(), master_key1)
+            .expect("Encryption should succeed");
+
+        // Decryption with wrong key should fail
+        let result = sutil.decrypt_from_base64_string(&encrypted, master_key2);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_decrypt_invalid_base64() {
+        let sutil = SecurityUtil::new();
+        let master_key = "test_key".as_bytes();
+        let invalid_base64 = "not-valid-base64!!!";
+
+        let result = sutil.decrypt_from_base64_string(invalid_base64, master_key);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_decrypt_truncated_ciphertext() {
+        let sutil = SecurityUtil::new();
+        let master_key = "test_key".as_bytes();
+
+        // Create valid base64 but with insufficient bytes (less than nonce + salt)
+        let short_bytes = vec![0u8; 10];
+        let short_base64 = sutil.base64_encode(&short_bytes).unwrap();
+
+        let result = sutil.decrypt_from_base64_string(&short_base64, master_key);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_base64_encode_empty() {
+        let sutil = SecurityUtil::new();
+        let empty: &[u8] = &[];
+        let encoded = sutil.base64_encode(empty).expect("Encode should succeed");
+        assert_eq!(encoded, "");
+    }
+
+    #[test]
+    fn test_base64_decode_empty() {
+        let sutil = SecurityUtil::new();
+        let decoded = sutil.base64_decode("").expect("Decode should succeed");
+        let expected: Vec<u8> = vec![];
+        assert_eq!(decoded, expected);
+    }
+
+    #[test]
+    fn test_generate_password_min_length() {
+        let sutil = SecurityUtil::new();
+        let password = sutil
+            .generate_password(1)
+            .expect("Password generation should succeed");
+        assert_eq!(password.len(), 1);
+    }
+
+    #[test]
+    fn test_generate_password_uniqueness() {
+        let sutil = SecurityUtil::new();
+        let password1 = sutil
+            .generate_password(64)
+            .expect("Password generation should succeed");
+        let password2 = sutil
+            .generate_password(64)
+            .expect("Password generation should succeed");
+
+        // Two randomly generated passwords should be different
+        assert_ne!(password1, password2);
+    }
+
+    #[test]
+    fn test_encrypt_different_nonces() {
+        let sutil = SecurityUtil::new();
+        let master_key = "test_key".as_bytes();
+        let text = "same text";
+
+        // Encrypt the same text twice
+        let encrypted1 = sutil
+            .encrypt_to_base64_string(text.as_bytes(), master_key)
+            .expect("Encryption should succeed");
+        let encrypted2 = sutil
+            .encrypt_to_base64_string(text.as_bytes(), master_key)
+            .expect("Encryption should succeed");
+
+        // Encrypted results should be different due to random nonce
+        assert_ne!(encrypted1, encrypted2);
+
+        // But both should decrypt to the same plaintext
+        let decrypted1 = sutil
+            .decrypt_from_base64_string(&encrypted1, master_key)
+            .expect("Decryption should succeed");
+        let decrypted2 = sutil
+            .decrypt_from_base64_string(&encrypted2, master_key)
+            .expect("Decryption should succeed");
+
+        assert_eq!(decrypted1, text.as_bytes());
+        assert_eq!(decrypted2, text.as_bytes());
+    }
+
+    #[test]
+    fn test_base64_roundtrip_various_inputs() {
+        let sutil = SecurityUtil::new();
+
+        let all_bytes: Vec<u8> = (0..=255).collect();
+        let zero_bytes = [0u8; 100];
+
+        let test_cases: Vec<&[u8]> = vec![
+            b"",
+            b"a",
+            b"hello world",
+            b"special chars: !@#$%^&*()",
+            &zero_bytes,
+            &all_bytes,
+        ];
+
+        for test_data in test_cases {
+            let encoded = sutil
+                .base64_encode(test_data)
+                .expect("Encoding should succeed");
+            let decoded = sutil
+                .base64_decode(&encoded)
+                .expect("Decoding should succeed");
+            assert_eq!(decoded, test_data);
+        }
+    }
+
+    #[test]
+    fn test_security_util_default_trait() {
+        let util1 = SecurityUtil::new();
+        let util2 = SecurityUtil::default();
+
+        // Both should work identically
+        let test_data = b"test";
+        let encoded1 = util1.base64_encode(test_data).unwrap();
+        let encoded2 = util2.base64_encode(test_data).unwrap();
+
+        assert_eq!(encoded1, encoded2);
     }
 }

--- a/tests/handler_test.rs
+++ b/tests/handler_test.rs
@@ -1,0 +1,51 @@
+// Copyright (C) 2026 The pgmoneta community
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+//! Integration tests for pgmoneta_mcp handler
+//!
+//! These tests verify core functionality without requiring a running pgmoneta server.
+//! They focus on testing public APIs and basic initialization for handlers.
+
+use pgmoneta_mcp::handler::PgmonetaHandler;
+use rmcp::ServerHandler;
+
+#[test]
+fn test_handler_initialization() {
+    let handler = PgmonetaHandler::new();
+
+    // Verify handler can be created
+    let info = handler.get_info();
+
+    // Check server info
+    assert!(info.instructions.is_some());
+    let instructions = info.instructions.unwrap();
+    assert!(instructions.contains("pgmoneta"));
+
+    // Verify capabilities
+    assert!(info.capabilities.tools.is_some());
+}
+
+#[test]
+fn test_handler_default_trait() {
+    let handler1 = PgmonetaHandler::new();
+    let handler2 = PgmonetaHandler::default();
+
+    // Both should produce valid handlers
+    let info1 = handler1.get_info();
+    let info2 = handler2.get_info();
+
+    assert!(info1.instructions.is_some());
+    assert!(info2.instructions.is_some());
+}


### PR DESCRIPTION
Adds missing user-management subcommands, output formats, and password-generation helpers.

Added:
  - `user del`, `user edit`, `user ls`
  - output format flag `-F/--format` with `text` and `json`
  - password generation options (`-g/--generate`, `-l/--length`) for both user operations and master-key
  - structured admin responses (`command`, `outcome`, optional `users`, optional `generated_password`) and unified text/JSON output rendering.
  - secure password generation utility in `SecurityUtil` using `OsRng`, with random-byte zeroization after use.
  - tests
 
Notes:
  - went with `--help` instead of `-?`
  - `user ls` returns success with an empty user list if the target file does not exist.
  - `user del`/`user edit` now return explicit errors for missing files/users/admin section.

<a href="https://asciinema.org/a/795298" target="_blank"><img src="https://asciinema.org/a/795298.svg" /></a>

closes: #9 