### PR TITLE
[#7] Add API documentation for client and handler modules

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -25,6 +25,10 @@ use std::fmt::Debug;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpStream;
 
+/// Represents the header of a request sent to the pgmoneta server.
+///
+/// Contains metadata such as the command code, client version,
+/// formatting preferences, and security settings.
 #[derive(Serialize, Clone, Debug)]
 struct RequestHeader {
     #[serde(rename = "Command")]
@@ -41,6 +45,9 @@ struct RequestHeader {
     encryption: u8,
 }
 
+/// A wrapper structure that combines a request header with its specific payload.
+///
+/// This is the final serialized object sent over the TCP connection to pgmoneta.
 #[derive(Serialize, Clone, Debug)]
 struct PgmonetaRequest<R>
 where
@@ -52,8 +59,16 @@ where
     request: R,
 }
 
+/// Handles network communication with the backend pgmoneta server.
+///
+/// This client manages the lifecycle of a request: building headers,
+/// authenticating, opening a TCP stream, writing the payload, and reading the response.
 pub struct PgmonetaClient;
 impl PgmonetaClient {
+    /// Constructs a standard request header for a given command.
+    ///
+    /// The header includes the current local timestamp and defaults to
+    /// no encryption or compression, expecting a JSON response.
     fn build_request_header(command: u32) -> RequestHeader {
         let timestamp = Local::now().format("%Y%m%d%H%M%S").to_string();
         RequestHeader {
@@ -66,6 +81,16 @@ impl PgmonetaClient {
         }
     }
 
+    /// Establishes an authenticated TCP connection to the pgmoneta server.
+    ///
+    /// Looks up the provided `username` in the configuration to find the encrypted
+    /// password, decrypts it using the master key, and initiates the connection.
+    ///
+    /// # Arguments
+    /// * `username` - The admin username requesting the connection.
+    ///
+    /// # Returns
+    /// An authenticated `TcpStream` ready for read/write operations.
     async fn connect_to_server(username: &str) -> anyhow::Result<TcpStream> {
         let config = CONFIG.get().expect("Configuration should be enabled");
         let security_util = SecurityUtil::new();
@@ -94,6 +119,13 @@ impl PgmonetaClient {
         Ok(stream)
     }
 
+    /// Writes a serialized JSON request string to the active TCP stream.
+    ///
+    /// Protocol flow:
+    /// 1. Writes the compression flag.
+    /// 2. Writes the encryption flag.
+    /// 3. Writes the length of the payload.
+    /// 4. Writes the exact payload bytes.
     async fn write_request(request_str: &str, stream: &mut TcpStream) -> anyhow::Result<()> {
         let mut request_buf = Vec::new();
         request_buf.write_i32(request_str.len() as i32).await?;
@@ -105,6 +137,13 @@ impl PgmonetaClient {
         Ok(())
     }
 
+    /// Reads the response payload from the TCP stream.
+    ///
+    /// Protocol flow:
+    /// 1. Reads the compression flag.
+    /// 2. Reads the encryption flag.
+    /// 3. Reads the payload length.
+    /// 4. Reads the exact number of bytes specified by the length.
     async fn read_response(stream: &mut TcpStream) -> anyhow::Result<String> {
         let _compression = stream.read_u8().await?;
         let _encryption = stream.read_u8().await?;
@@ -115,6 +154,15 @@ impl PgmonetaClient {
         Ok(response_str)
     }
 
+    /// End-to-end wrapper for sending a request to the pgmoneta server and awaiting its response.
+    ///
+    /// # Arguments
+    /// * `username` - The admin username making the request.
+    /// * `command` - The numeric command code (e.g., `Command::INFO`).
+    /// * `request` - The specific request payload object.
+    ///
+    /// # Returns
+    /// The raw string response from the pgmoneta server.
     async fn forward_request<R>(username: &str, command: u32, request: R) -> anyhow::Result<String>
     where
         R: Serialize + Clone + Debug,

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -29,6 +29,10 @@ use rmcp::{
 use serde_json::Map;
 use serde_json::Value;
 
+/// The core handler for incoming Model Context Protocol (MCP) requests.
+///
+/// This struct routes MCP tool calls from the client (like an AI model)
+/// to the appropriate internal functions that communicate with pgmoneta.
 #[derive(Clone)]
 pub struct PgmonetaHandler {
     tool_router: ToolRouter<PgmonetaHandler>,
@@ -36,12 +40,14 @@ pub struct PgmonetaHandler {
 
 #[tool_router]
 impl PgmonetaHandler {
+    /// Creates a new instance of the `PgmonetaHandler` with an initialized tool router.
     pub fn new() -> Self {
         Self {
             tool_router: Self::tool_router(),
         }
     }
 
+    /// Simple ping tool to verify the MCP server is responsive.
     #[tool(description = "Say hello to the client")]
     fn say_hello(&self) -> Result<CallToolResult, McpError> {
         Ok(CallToolResult::success(vec![Content::text(
@@ -49,6 +55,7 @@ impl PgmonetaHandler {
         )]))
     }
 
+    /// Tool for fetching detailed information about a specific backup.
     #[tool(
         description = "Get information of a backup using given backup ID and server name. \
     \"newest\", \"latest\" or \"oldest\" are also accepted as backup identifier.\
@@ -62,6 +69,7 @@ impl PgmonetaHandler {
         Self::_generate_call_tool_result(&result)
     }
 
+    /// Tool for listing available backups on a specified server.
     #[tool(description = "List backups of a server. \
         Specify asc or desc to determine the sorting order.\
         The backups are sorted in ascending order if not specified.")]
@@ -75,6 +83,9 @@ impl PgmonetaHandler {
 }
 
 impl PgmonetaHandler {
+    /// Parses the raw string response from pgmoneta into a JSON map.
+    ///
+    /// Ensures the response contains the required `Outcome` category key.
     fn _parse_and_check_result(result: &str) -> Result<Map<String, Value>, McpError> {
         let response: Map<String, Value> = serde_json::from_str(result).map_err(|e| {
             McpError::parse_error(format!("Failed to parse result {result}: {:?}", e), None)
@@ -88,6 +99,12 @@ impl PgmonetaHandler {
         Ok(response)
     }
 
+    /// Recursively translates numeric/raw fields in the pgmoneta response into human-readable formats.
+    ///
+    /// This includes:
+    /// * Formatting byte counts into human-readable file sizes (e.g., KB, MB).
+    /// * Converting LSNs (Log Sequence Numbers) into hex strings.
+    /// * Translating numeric enum codes (Compression, Encryption, Error) into descriptive strings.
     fn _translate_result<'a, M>(map: M) -> anyhow::Result<Map<String, Value>>
     where
         M: IntoIterator<Item = (&'a String, &'a Value)>,
@@ -173,6 +190,8 @@ impl PgmonetaHandler {
         Ok(trans_res)
     }
 
+    /// Wraps the parsed and translated pgmoneta response into a standardized `CallToolResult`
+    /// that can be sent back to the MCP client.
     fn _generate_call_tool_result(result: &str) -> Result<CallToolResult, McpError> {
         let res = Self::_parse_and_check_result(result)?;
         let trans_res = Self::_translate_result(&res).map_err(|e| {
@@ -196,6 +215,7 @@ impl Default for PgmonetaHandler {
 
 #[tool_handler]
 impl ServerHandler for PgmonetaHandler {
+    /// Provides the MCP initialization capabilities and metadata for this server.
     fn get_info(&self) -> ServerInfo {
         ServerInfo {
             protocol_version: ProtocolVersion::V_2024_11_05,
@@ -207,6 +227,7 @@ impl ServerHandler for PgmonetaHandler {
         }
     }
 
+    /// Handles the initial connection setup and handshake from an MCP client.
     async fn initialize(
         &self,
         _request: InitializeRequestParam,


### PR DESCRIPTION
**Description**
continues the work on Issue #7 by adding API-level documentation to the `client` and `handler` modules.

**Changes**
* **`handler.rs`**: Documented `PgmonetaHandler`, its exposed MCP tools, and the internal response processing methods.
* **`client.rs`**: Added documentation to `PgmonetaClient` and its internal methods, clarifying the TCP payload structure and the request lifecycle.

**Note on Private API Documentation:** I intentionally added `///` doc comments to the private structs and methods in `client.rs`. While these do not appear in the default public API `cargo doc` build, I included them to help for future contributors. If the project maintains a strict policy of only using `///` for the public API, just let me know and I can revert the private ones to standard `//` comments.

**Verification**
* Ran `cargo doc --no-deps --open` locally to verify accurate HTML rendering.
* Passed `cargo fmt` and `cargo clippy`.