### PR TITLE
[#45] Add status and status details command

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -21,6 +21,7 @@ mod info;
 mod mode;
 mod retention;
 mod shutdown;
+mod status;
 mod verify;
 
 use super::compression::CompressionUtil;

--- a/src/client/status.rs
+++ b/src/client/status.rs
@@ -1,0 +1,33 @@
+// Copyright (C) 2026 The pgmoneta community
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+use super::PgmonetaClient;
+use crate::constant::Command;
+use serde::Serialize;
+
+#[derive(Serialize, Clone, Debug)]
+struct StatusRequest {}
+
+impl PgmonetaClient {
+    pub async fn request_status(username: &str) -> anyhow::Result<String> {
+        let status_request = StatusRequest {};
+        Self::forward_request(username, Command::STATUS, status_request).await
+    }
+
+    pub async fn request_status_details(username: &str) -> anyhow::Result<String> {
+        let status_request = StatusRequest {};
+        Self::forward_request(username, Command::STATUS_DETAILS, status_request).await
+    }
+}

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -21,6 +21,7 @@ pub mod info;
 pub mod mode;
 pub mod retention;
 pub mod shutdown;
+pub mod status;
 pub mod verify;
 
 use super::constant::*;
@@ -60,6 +61,8 @@ impl PgmonetaHandler {
             .with_async_tool::<conf::ConfGetTool>()
             .with_async_tool::<conf::ConfSetTool>()
             .with_async_tool::<mode::SetModeTool>()
+            .with_async_tool::<status::GetStatusTool>()
+            .with_async_tool::<status::GetStatusDetailsTool>()
             .with_async_tool::<compression::CompressFileTool>()
             .with_async_tool::<compression::DecompressFileTool>()
             .with_async_tool::<encryption::EncryptFileTool>()

--- a/src/handler/status.rs
+++ b/src/handler/status.rs
@@ -1,0 +1,193 @@
+// Copyright (C) 2026 The pgmoneta community
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+use std::borrow::Cow;
+use std::sync::Arc;
+
+use super::PgmonetaHandler;
+use crate::client::PgmonetaClient;
+use rmcp::ErrorData as McpError;
+use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
+use rmcp::model::JsonObject;
+use rmcp::schemars;
+
+#[derive(Debug, Default, serde::Deserialize, schemars::JsonSchema)]
+pub struct StatusRequest {
+    pub username: String,
+}
+
+/// Tool for retrieving the overall status of the pgmoneta server.
+pub struct GetStatusTool;
+
+impl ToolBase for GetStatusTool {
+    type Parameter = StatusRequest;
+    type Output = String;
+    type Error = McpError;
+
+    fn name() -> Cow<'static, str> {
+        "status".into()
+    }
+
+    fn description() -> Option<Cow<'static, str>> {
+        Some(
+            "Get the status of the pgmoneta server. \
+            Returns general information such as server version, number of servers, \
+            total space, free space and used space."
+                .into(),
+        )
+    }
+
+    fn output_schema() -> Option<Arc<JsonObject>> {
+        None
+    }
+}
+
+impl AsyncTool<PgmonetaHandler> for GetStatusTool {
+    async fn invoke(
+        _service: &PgmonetaHandler,
+        request: StatusRequest,
+    ) -> Result<String, McpError> {
+        let result = PgmonetaClient::request_status(&request.username)
+            .await
+            .map_err(|e| {
+                McpError::internal_error(format!("Failed to retrieve status: {:?}", e), None)
+            })?;
+        PgmonetaHandler::generate_call_tool_result_string(&result)
+    }
+}
+
+/// Tool for retrieving detailed per-server status from pgmoneta.
+pub struct GetStatusDetailsTool;
+
+impl ToolBase for GetStatusDetailsTool {
+    type Parameter = StatusRequest;
+    type Output = String;
+    type Error = McpError;
+
+    fn name() -> Cow<'static, str> {
+        "status_details".into()
+    }
+
+    fn description() -> Option<Cow<'static, str>> {
+        Some(
+            "Get detailed status of the pgmoneta server. \
+            Returns per-server information including backup sizes, WAL, \
+            retention policy, hot standby size and workers."
+                .into(),
+        )
+    }
+
+    fn output_schema() -> Option<Arc<JsonObject>> {
+        None
+    }
+}
+
+impl AsyncTool<PgmonetaHandler> for GetStatusDetailsTool {
+    async fn invoke(
+        _service: &PgmonetaHandler,
+        request: StatusRequest,
+    ) -> Result<String, McpError> {
+        let result = PgmonetaClient::request_status_details(&request.username)
+            .await
+            .map_err(|e| {
+                McpError::internal_error(
+                    format!("Failed to retrieve status details: {:?}", e),
+                    None,
+                )
+            })?;
+        PgmonetaHandler::generate_call_tool_result_string(&result)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::handler::PgmonetaHandler;
+    use rmcp::handler::server::router::tool::ToolBase;
+    use serde_json::{Map, Value};
+
+    #[test]
+    fn test_get_status_tool_metadata() {
+        assert_eq!(GetStatusTool::name(), "status");
+        let desc = GetStatusTool::description();
+        assert!(desc.is_some());
+        assert!(desc.unwrap().contains("status"));
+    }
+
+    #[test]
+    fn test_get_status_details_tool_metadata() {
+        assert_eq!(GetStatusDetailsTool::name(), "status_details");
+        let desc = GetStatusDetailsTool::description();
+        assert!(desc.is_some());
+        assert!(desc.unwrap().contains("detailed"));
+    }
+
+    #[test]
+    fn test_handler_has_status_tools() {
+        let tools = PgmonetaHandler::tool_router().list_all();
+        let tool_names: Vec<&str> = tools.iter().map(|t| t.name.as_ref()).collect();
+        assert!(
+            tool_names.contains(&"status"),
+            "status tool should be registered, found: {:?}",
+            tool_names
+        );
+        assert!(
+            tool_names.contains(&"status_details"),
+            "status_details tool should be registered, found: {:?}",
+            tool_names
+        );
+    }
+
+    #[test]
+    fn test_generate_call_tool_result_string_status() {
+        let response = r#"{"Outcome": {"Status": true, "Command": 7}, "TotalSpace": 1073741824, "FreeSpace": 536870912, "UsedSpace": 536870912}"#;
+        let result = PgmonetaHandler::generate_call_tool_result_string(response);
+
+        assert!(result.is_ok());
+        let output = result.unwrap();
+        let parsed: Map<String, Value> = serde_json::from_str(&output).unwrap();
+        let outcome = parsed["Outcome"].as_object().unwrap();
+        assert_eq!(outcome["Command"], "status");
+        assert_eq!(parsed["TotalSpace"], "1.00 GB");
+        assert_eq!(parsed["FreeSpace"], "512.00 MB");
+        assert_eq!(parsed["UsedSpace"], "512.00 MB");
+    }
+
+    #[test]
+    fn test_generate_call_tool_result_string_status_details() {
+        let response = r#"{"Outcome": {"Status": true, "Command": 8}, "HotStandbySize": 2147483648, "WorkspaceFreeSpace": 10737418240}"#;
+        let result = PgmonetaHandler::generate_call_tool_result_string(response);
+
+        assert!(result.is_ok());
+        let output = result.unwrap();
+        let parsed: Map<String, Value> = serde_json::from_str(&output).unwrap();
+        let outcome = parsed["Outcome"].as_object().unwrap();
+        assert_eq!(outcome["Command"], "status details");
+        assert_eq!(parsed["HotStandbySize"], "2.00 GB");
+        assert_eq!(parsed["WorkspaceFreeSpace"], "10.00 GB");
+    }
+
+    #[test]
+    fn test_status_details_response_with_error() {
+        let response = r#"{"Outcome": {"Status": false, "Command": 8, "Error": 1100}}"#;
+        let result = PgmonetaHandler::generate_call_tool_result_string(response);
+
+        assert!(result.is_ok());
+        let output = result.unwrap();
+        let parsed: Map<String, Value> = serde_json::from_str(&output).unwrap();
+        let outcome = parsed["Outcome"].as_object().unwrap();
+        assert_eq!(outcome["Error"], "Status details: no fork");
+    }
+}

--- a/tests/status_test.rs
+++ b/tests/status_test.rs
@@ -1,0 +1,78 @@
+// Copyright (C) 2026 The pgmoneta community
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+use pgmoneta_mcp::handler::PgmonetaHandler;
+use pgmoneta_mcp::handler::status::{GetStatusDetailsTool, GetStatusTool, StatusRequest};
+use rmcp::handler::server::router::tool::AsyncTool;
+use serde_json::Value;
+
+mod common;
+
+fn assert_command_and_status(response: &str, json: &Value, expected_command: &str) {
+    let header = json
+        .get("Header")
+        .unwrap_or_else(|| panic!("Header field missing in response: {response}"));
+    let command = header
+        .get("Command")
+        .unwrap_or_else(|| panic!("Command field missing in Header: {response}"));
+    assert_eq!(
+        command, expected_command,
+        "unexpected command in response: {response}"
+    );
+
+    let outcome = json
+        .get("Outcome")
+        .unwrap_or_else(|| panic!("Outcome field missing in response: {response}"));
+    let status = outcome
+        .get("Status")
+        .unwrap_or_else(|| panic!("Status field missing in Outcome: {response}"));
+    assert_eq!(status, true, "unexpected status in response: {response}");
+}
+
+#[tokio::test]
+#[ignore = "requires pgmoneta stack (see test/check.sh and full-test CI job)"]
+async fn get_status_test() {
+    common::init_config();
+
+    let handler = PgmonetaHandler::new();
+    let request = StatusRequest {
+        username: "backup_user".to_string(),
+    };
+
+    let response = GetStatusTool::invoke(&handler, request)
+        .await
+        .expect("get_status should succeed");
+
+    let json: Value = serde_json::from_str(&response).expect("response should be valid json");
+    assert_command_and_status(&response, &json, "status");
+}
+
+#[tokio::test]
+#[ignore = "requires pgmoneta stack (see test/check.sh and full-test CI job)"]
+async fn get_status_details_test() {
+    common::init_config();
+
+    let handler = PgmonetaHandler::new();
+    let request = StatusRequest {
+        username: "backup_user".to_string(),
+    };
+
+    let response = GetStatusDetailsTool::invoke(&handler, request)
+        .await
+        .expect("get_status_details should succeed");
+
+    let json: Value = serde_json::from_str(&response).expect("response should be valid json");
+    assert_command_and_status(&response, &json, "status details");
+}


### PR DESCRIPTION
# Summary
  - Add `get_status` and `get_status_details` MCP tools using `Command::STATUS` (7) and `Command::STATUS_DETAILS` (8)
  - New files: `src/client/status.rs`, `src/handler/status.rs`
  - Add unit tests for tool registration, response parsing and field translation
  
# Closes #45 