### PR TITLE
[#53] Add interactive MCP Inspector

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,9 +63,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.21"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -78,15 +78,15 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.7"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
 dependencies = [
  "utf8parse",
 ]
@@ -113,9 +113,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.100"
+version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "arraydeque"
@@ -148,9 +148,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "axum"
-version = "0.8.4"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "021e862c184ae977658b36c4500f7feac3221ca5da43e3f25bd04ab6c79a29b5"
+checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
 dependencies = [
  "axum-core",
  "axum-macros",
@@ -168,8 +168,7 @@ dependencies = [
  "mime",
  "percent-encoding",
  "pin-project-lite",
- "rustversion",
- "serde",
+ "serde_core",
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
@@ -183,9 +182,9 @@ dependencies = [
 
 [[package]]
 name = "axum-core"
-version = "0.5.2"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68464cd0412f486726fb3373129ef5d2993f90c34bc2bc1c1e9943b2f4fc7ca6"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
 dependencies = [
  "bytes",
  "futures-core",
@@ -194,7 +193,6 @@ dependencies = [
  "http-body-util",
  "mime",
  "pin-project-lite",
- "rustversion",
  "sync_wrapper",
  "tower-layer",
  "tower-service",
@@ -220,9 +218,9 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 dependencies = [
  "serde_core",
 ]
@@ -238,15 +236,15 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.19.0"
+version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
 name = "bytes"
-version = "1.10.1"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "bzip2"
@@ -270,9 +268,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.45"
+version = "1.2.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35900b6c8d709fb1d854671ae27aeaa9eec2f8b01b364e1619a40da3e6fe2afe"
+checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -305,9 +303,9 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.42"
+version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "145052bdd345b87320e369255277e3fb5152762ad123a901ef5c262dd38fe8d2"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -329,9 +327,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.53"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9e340e012a1bf4935f5282ed1436d1489548e8f72308207ea5df0e23d2d03f8"
+checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -339,9 +337,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.53"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d76b5d13eaa18c901fd2f7fca939fefe3a0727a953561fefdf3b2922b8569d00"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
  "anstream",
  "anstyle",
@@ -351,9 +349,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.49"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a0b5487afeab2deb2ff4e03a807ad1a03ac532ff5a2cee5d86884440c7f7671"
+checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -363,24 +361,24 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.6"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "config"
-version = "0.15.19"
+version = "0.15.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b30fa8254caad766fc03cb0ccae691e14bf3bd72bfff27f72802ce729551b3d6"
+checksum = "8e68cfe19cd7d23ffde002c24ffa5cda73931913ef394d5eaaa32037dc940c0c"
 dependencies = [
  "async-trait",
- "convert_case",
+ "convert_case 0.6.0",
  "json5",
  "pathdiff",
  "ron",
@@ -408,7 +406,7 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
 dependencies = [
- "getrandom 0.2.16",
+ "getrandom 0.2.17",
  "once_cell",
  "tiny-keccak",
 ]
@@ -418,6 +416,15 @@ name = "convert_case"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "convert_case"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
 dependencies = [
  "unicode-segmentation",
 ]
@@ -471,6 +478,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "crossterm"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
+dependencies = [
+ "bitflags",
+ "crossterm_winapi",
+ "derive_more",
+ "document-features",
+ "mio",
+ "parking_lot",
+ "rustix",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "crunchy"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -478,9 +512,9 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "rand_core 0.6.4",
@@ -532,11 +566,33 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.5.5"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ececcb659e7ba858fb4f10388c250a7252eb0a27373f1a72b8748afdd248e587"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
+]
+
+[[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "convert_case 0.10.0",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn",
 ]
 
 [[package]]
@@ -571,6 +627,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
+]
+
+[[package]]
 name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -593,9 +658,9 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "erased-serde"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89e8918065695684b2b0702da20382d5ae6065cf3327bc2d6436bd49a71ce9f3"
+checksum = "d2add8a07dd6a8d93ff627029c51de145e12686fbc36ecb298ac22e74cf02dec"
 dependencies = [
  "serde",
  "serde_core",
@@ -603,10 +668,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "find-msvc-tools"
-version = "0.1.4"
+name = "errno"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52051878f80a721bb68ebfbc930e07b65ba72f2da88968ea5c06fd6ca3d3a127"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "flate2"
@@ -619,12 +700,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fnv"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
 name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -632,18 +707,18 @@ checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "form_urlencoded"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
 
 [[package]]
 name = "futures"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -656,9 +731,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -666,15 +741,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -683,15 +758,15 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -700,21 +775,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
 name = "futures-util"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -724,8 +799,16 @@ dependencies = [
  "futures-task",
  "memchr",
  "pin-project-lite",
- "pin-utils",
  "slab",
+]
+
+[[package]]
+name = "fuzzy-matcher"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54614a3312934d066701a80f20f15fa3b56d67ac7722b39eea5b4c9dd1d66c94"
+dependencies = [
+ "thread_local",
 ]
 
 [[package]]
@@ -740,9 +823,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -760,7 +843,7 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi 5.2.0",
+ "r-efi 5.3.0",
  "wasip2",
  "wasm-bindgen",
 ]
@@ -836,21 +919,20 @@ dependencies = [
 
 [[package]]
 name = "home"
-version = "0.5.11"
+version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "http"
-version = "1.3.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4a85d31aea989eead29a3aaf9e1115a180df8282431156e533de47660892565"
+checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
 dependencies = [
  "bytes",
- "fnv",
  "itoa",
 ]
 
@@ -953,9 +1035,9 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.64"
+version = "0.1.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33e57f83510bb73707521ebaffa789ec8caf86f9657cad665b092b581d40e9fb"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -977,9 +1059,9 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.0.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "200072f5d0e3614556f94a9930d5dc3e0662a652823904c3a75dc3b0af7fee47"
+checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
 dependencies = [
  "displaydoc",
  "potential_utf",
@@ -990,9 +1072,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.0.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cde2700ccaed3872079a65fb1a78f6c0a36c91570f28755dda67bc8f7d9f00a"
+checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -1003,11 +1085,10 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.0.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "436880e8e18df4d7bbc06d58432329d6458cc84531f7ac5f024e93deadb37979"
+checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
 dependencies = [
- "displaydoc",
  "icu_collections",
  "icu_normalizer_data",
  "icu_properties",
@@ -1018,42 +1099,38 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.0.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00210d6893afc98edb752b664b8890f0ef174c8adbb8d0be9710fa66fbbf72d3"
+checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
 
 [[package]]
 name = "icu_properties"
-version = "2.0.0"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2549ca8c7241c82f59c80ba2a6f415d931c5b58d24fb8412caa1a1f02c49139a"
+checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
 dependencies = [
- "displaydoc",
  "icu_collections",
  "icu_locale_core",
  "icu_properties_data",
  "icu_provider",
- "potential_utf",
  "zerotrie",
  "zerovec",
 ]
 
 [[package]]
 name = "icu_properties_data"
-version = "2.0.0"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8197e866e47b68f8f7d95249e172903bec06004b18b2937f1095d40a0c57de04"
+checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
 
 [[package]]
 name = "icu_provider"
-version = "2.0.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03c80da27b5f4187909049ee2d72f276f0d9f99a42c306bd0131ecfe04d8e5af"
+checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
- "stable_deref_trait",
- "tinystr",
  "writeable",
  "yoke",
  "zerofrom",
@@ -1075,9 +1152,9 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
-version = "1.0.3"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
 dependencies = [
  "idna_adapter",
  "smallvec",
@@ -1116,10 +1193,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "ipnet"
-version = "2.11.0"
+name = "inquire"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+checksum = "6654738b8024300cf062d04a1c13c10c8e2cea598ec1c47dc9b6641159429756"
+dependencies = [
+ "bitflags",
+ "crossterm",
+ "dyn-clone",
+ "fuzzy-matcher",
+ "unicode-segmentation",
+ "unicode-width",
+]
+
+[[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "iri-string"
@@ -1139,9 +1230,9 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itoa"
-version = "1.0.15"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jobserver"
@@ -1188,15 +1279,27 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.177"
+version = "0.2.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
+checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
+checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+
+[[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
 name = "lock_api"
@@ -1209,9 +1312,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.28"
+version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "lru-slab"
@@ -1255,9 +1358,9 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "memchr"
-version = "2.7.6"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "mime"
@@ -1277,11 +1380,12 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69d83b0086dc8ecf3ce9ae2874b2d1290252e2a30720bea58a5c6639b0092873"
+checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
 dependencies = [
  "libc",
+ "log",
  "wasi",
  "windows-sys 0.61.2",
 ]
@@ -1297,9 +1401,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
 
 [[package]]
 name = "num-traits"
@@ -1318,7 +1422,7 @@ checksum = "51e219e79014df21a225b1860a479e2dcd7cbd9130f4defd4bd0e191ea31d67d"
 dependencies = [
  "base64",
  "chrono",
- "getrandom 0.2.16",
+ "getrandom 0.2.17",
  "http",
  "rand 0.8.5",
  "serde",
@@ -1331,9 +1435,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "once_cell_polyfill"
@@ -1404,15 +1508,15 @@ dependencies = [
 
 [[package]]
 name = "percent-encoding"
-version = "2.3.1"
+version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pest"
-version = "2.8.3"
+version = "2.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "989e7521a040efde50c3ab6bbadafbe15ab6dc042686926be59ac35d74607df4"
+checksum = "e0848c601009d37dfa3430c4666e147e49cdcf1b92ecd3e63657d8a5f19da662"
 dependencies = [
  "memchr",
  "ucd-trie",
@@ -1420,9 +1524,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.8.3"
+version = "2.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "187da9a3030dbafabbbfb20cb323b976dc7b7ce91fcd84f2f74d6e31d378e2de"
+checksum = "11f486f1ea21e6c10ed15d5a7c77165d0ee443402f0780849d1768e7d9d6fe77"
 dependencies = [
  "pest",
  "pest_generator",
@@ -1430,9 +1534,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.8.3"
+version = "2.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49b401d98f5757ebe97a26085998d6c0eecec4995cad6ab7fc30ffdf4b052843"
+checksum = "8040c4647b13b210a963c1ed407c1ff4fdfa01c31d6d2a098218702e6664f94f"
 dependencies = [
  "pest",
  "pest_meta",
@@ -1443,9 +1547,9 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.8.3"
+version = "2.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72f27a2cfee9f9039c4d86faa5af122a0ac3851441a34865b8a043b46be0065a"
+checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
 dependencies = [
  "pest",
  "sha2",
@@ -1467,11 +1571,12 @@ dependencies = [
  "flate2",
  "hmac",
  "home",
+ "inquire",
  "log",
  "lz4",
  "once_cell",
  "pbkdf2",
- "rand 0.9.1",
+ "rand 0.9.2",
  "reqwest 0.12.28",
  "rmcp",
  "rpassword",
@@ -1481,10 +1586,12 @@ dependencies = [
  "serde_json",
  "sha2",
  "syslog-tracing",
+ "tempfile",
  "tokio",
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
+ "treelog",
  "winlog2",
  "zeroize",
  "zstd",
@@ -1492,9 +1599,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pin-utils"
@@ -1522,9 +1629,9 @@ dependencies = [
 
 [[package]]
 name = "potential_utf"
-version = "0.1.2"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5a7c30837279ca13e7c867e9e40053bc68740f988cb07f7ca6df43cc734b585"
+checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
 dependencies = [
  "zerovec",
 ]
@@ -1556,9 +1663,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.103"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ee95bc4ef87b8d5ba32e8b7714ccc834865276eab0aed5c9958d00ec45f49e8"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
@@ -1577,7 +1684,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "web-time",
@@ -1592,13 +1699,13 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.1",
+ "rand 0.9.2",
  "ring",
  "rustc-hash",
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tinyvec",
  "tracing",
  "web-time",
@@ -1620,18 +1727,18 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.42"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a338cc41d27e6cc6dce6cefc13a0729dfbb81c262b1f519331575dd80ef3067f"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "r-efi"
-version = "5.2.0"
+version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "r-efi"
@@ -1652,12 +1759,12 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha 0.9.0",
- "rand_core 0.9.3",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1688,7 +1795,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.9.3",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1697,14 +1804,14 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.16",
+ "getrandom 0.2.17",
 ]
 
 [[package]]
 name = "rand_core"
-version = "0.9.3"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
 ]
@@ -1746,9 +1853,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1757,9 +1864,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.8"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reqwest"
@@ -1847,7 +1954,7 @@ checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom 0.2.16",
+ "getrandom 0.2.17",
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
@@ -1877,7 +1984,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sse-stream",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -1952,6 +2059,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "rustls"
 version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1994,15 +2123,15 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryu"
-version = "1.0.20"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "schemars"
-version = "1.1.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9558e172d4e8533736ba97870c4b2cd63f84b382a3d6eb063da41b91cce17289"
+checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
 dependencies = [
  "chrono",
  "dyn-clone",
@@ -2014,9 +2143,9 @@ dependencies = [
 
 [[package]]
 name = "schemars_derive"
-version = "1.1.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "301858a4023d78debd2353c7426dc486001bddc91ae31a76fb1f55132f7e2633"
+checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2113,32 +2242,33 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.145"
+version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
  "itoa",
  "memchr",
- "ryu",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
  "serde",
  "serde_core",
 ]
 
 [[package]]
-name = "serde_path_to_error"
-version = "0.1.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59fab13f937fa393d08645bf3a84bdfe86e296747b506ada67bb15f10f218b2a"
-dependencies = [
- "itoa",
- "serde",
-]
-
-[[package]]
 name = "serde_spanned"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e24345aa0fe688594e73770a5f6d1b216508b4f93484c0026d521acd30134392"
+checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
 dependencies = [
  "serde_core",
 ]
@@ -2182,11 +2312,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
-name = "signal-hook-registry"
-version = "1.4.6"
+name = "signal-hook"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2a4719bff48cee6b39d12c020eeb490953ad2443b7055bd0b21fca26bd8c28b"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
 dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
  "libc",
 ]
 
@@ -2198,9 +2350,9 @@ checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
 
 [[package]]
 name = "slab"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
@@ -2210,12 +2362,12 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
-version = "0.6.1"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17129e116933cf371d018bb80ae557e889637989d8638274fb25622827b03881"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2233,9 +2385,9 @@ dependencies = [
 
 [[package]]
 name = "stable_deref_trait"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "strsim"
@@ -2251,9 +2403,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.109"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f17c7e013e88258aa9543dcbe81aca68a667a9ac37cd69c9fbc07858bfe0e2f"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2292,6 +2444,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.2",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2302,11 +2467,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.17"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl 2.0.17",
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -2322,9 +2487,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.17"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2342,30 +2507,30 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.44"
+version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e7d9e3bb61134e77bde20dd4825b97c010155709965fedf0f49bb138e52a9d"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "itoa",
  "num-conv",
  "powerfmt",
- "serde",
+ "serde_core",
  "time-core",
  "time-macros",
 ]
 
 [[package]]
 name = "time-core"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40868e7c1d2f0b8d73e4a8c7f0ff63af4f6d19be117e90bd73eb1d62cf831c6b"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "time-macros"
-version = "0.2.24"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30cfb0125f12d9c277f35663a0a33f8c30190f4e4574868a330595412d34ebf3"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",
@@ -2382,9 +2547,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d4f6d1145dcb577acf783d4e601bc1d76a13337bb54e6233add580b07344c8b"
+checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -2407,9 +2572,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.48.0"
+version = "1.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff360e02eab121e0bc37a2d3b4d4dc622e6eda3a8e5253d5435ecf5bd4c68408"
+checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
 dependencies = [
  "bytes",
  "libc",
@@ -2424,9 +2589,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
+checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2445,9 +2610,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.17"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eca58d7bba4a75707817a2c44174253f9236b2d5fbd055602e9d5c07c139a047"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -2456,9 +2621,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.17"
+version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2efa149fe76073d6e8fd97ef4f4eca7b67f599660115591483572e406e165594"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
 dependencies = [
  "bytes",
  "futures-core",
@@ -2469,9 +2634,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.9.8"
+version = "1.0.7+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0dc8b1fb61449e27716ec0e1bdf0f6b8f3e8f6b05391e8497b8b6d7804ea6d8"
+checksum = "dd28d57d8a6f6e458bc0b8784f8fdcc4b99a437936056fa122cb234f18656a96"
 dependencies = [
  "indexmap",
  "serde_core",
@@ -2484,33 +2649,33 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.7.3"
+version = "1.0.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2cdb639ebbc97961c51720f858597f7f24c4fc295327923af55b74c3c724533"
+checksum = "9b320e741db58cac564e26c607d3cc1fdc4a88fd36c879568c07856ed83ff3e9"
 dependencies = [
  "serde_core",
 ]
 
 [[package]]
 name = "toml_parser"
-version = "1.0.4"
+version = "1.0.10+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0cbe268d35bdb4bb5a56a2de88d0ad0eb70af5384a99d648cd4b3d04039800e"
+checksum = "7df25b4befd31c4816df190124375d5a20c6b6921e2cad937316de3fccd63420"
 dependencies = [
  "winnow",
 ]
 
 [[package]]
 name = "toml_writer"
-version = "1.0.6+spec-1.1.0"
+version = "1.0.7+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607"
+checksum = "f17aaa1c6e3dc22b1da4b6bba97d066e354c7945cac2f7852d4e4e7ca7a6b56d"
 
 [[package]]
 name = "tower"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
@@ -2571,7 +2736,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "786d480bce6247ab75f005b14ae1624ad978d3029d9113f0a22fa1ac773faeaf"
 dependencies = [
  "crossbeam-channel",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "time",
  "tracing-subscriber",
 ]
@@ -2610,9 +2775,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.22"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
  "chrono",
  "matchers",
@@ -2625,6 +2790,16 @@ dependencies = [
  "tracing",
  "tracing-core",
  "tracing-log",
+]
+
+[[package]]
+name = "treelog"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8ef568e76b5fb29dcccd133677bc93c9588383651506351ccf101a7374496c6"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -2641,9 +2816,9 @@ checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
 name = "typenum"
-version = "1.18.0"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
+checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
 name = "ucd-trie"
@@ -2653,15 +2828,21 @@ checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.22"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-segmentation"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "unicode-xid"
@@ -2687,14 +2868,15 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
-version = "2.5.4"
+version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
 dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
  "serde",
+ "serde_derive",
 ]
 
 [[package]]
@@ -2711,11 +2893,11 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.18.1"
+version = "1.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f87b8aa10b915a06587d0dec516c282ff295b475d94abf425d62b57710070a2"
+checksum = "a68d3c8f01c0cfa54a75291d83601161799e4a89a39e0929f4b0354d88757a37"
 dependencies = [
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "js-sys",
  "wasm-bindgen",
 ]
@@ -2755,11 +2937,11 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.1+wasi-0.2.4"
+version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
+checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
 dependencies = [
- "wit-bindgen 0.46.0",
+ "wit-bindgen",
 ]
 
 [[package]]
@@ -2768,7 +2950,7 @@ version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
- "wit-bindgen 0.51.0",
+ "wit-bindgen",
 ]
 
 [[package]]
@@ -2911,6 +3093,28 @@ name = "widestring"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"
@@ -3143,7 +3347,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbcb7337a45c2471af9792c45ba69cc6142ce6f71d56e1cc7190848247e9e8c2"
 dependencies = [
  "log",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "widestring",
  "windows-sys 0.59.0",
  "winreg",
@@ -3152,9 +3356,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.7.13"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
+checksum = "a90e88e4667264a994d34e6d1ab2d26d398dcdca8b7f52bec8668957517fc7d8"
 dependencies = [
  "memchr",
 ]
@@ -3171,19 +3375,13 @@ dependencies = [
 
 [[package]]
 name = "winresource"
-version = "0.1.30"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e287ced0f21cd11f4035fe946fd3af145f068d1acb708afd248100f89ec7432d"
+checksum = "0986a8b1d586b7d3e4fe3d9ea39fb451ae22869dcea4aa109d287a374d866087"
 dependencies = [
  "toml",
  "version_check",
 ]
-
-[[package]]
-name = "wit-bindgen"
-version = "0.46.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 
 [[package]]
 name = "wit-bindgen"
@@ -3275,9 +3473,9 @@ dependencies = [
 
 [[package]]
 name = "writeable"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
+checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
 name = "yaml-rust2"
@@ -3292,11 +3490,10 @@ dependencies = [
 
 [[package]]
 name = "yoke"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f41bb01b8226ef4bfd589436a297c53d118f65921786300e427be8d487695cc"
+checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
 dependencies = [
- "serde",
  "stable_deref_trait",
  "yoke-derive",
  "zerofrom",
@@ -3304,9 +3501,9 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
+checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3316,18 +3513,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.25"
+version = "0.8.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1702d9583232ddb9174e01bb7c15a2ab8fb1bc6f227aa1233858c351a3ba0cb"
+checksum = "efbb2a062be311f2ba113ce66f697a4dc589f85e78a4aea276200804cea0ed87"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.25"
+version = "0.8.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28a6e20d751156648aa063f3800b706ee209a32c0b4d9f24be3d980b01be55ef"
+checksum = "0e8bc7269b54418e7aeeef514aa68f8690b8c0489a06b0136e5f57c4c5ccab89"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3374,9 +3571,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.2"
+version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a05eb080e015ba39cc9e23bbe5e7fb04d5fb040350f99f34e338d5fdd294428"
+checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -3385,14 +3582,20 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
+checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
 
 [[package]]
 name = "zstd"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,10 @@ path = "src/bin/server.rs"
 name = "pgmoneta-mcp-admin"
 path = "src/bin/admin.rs"
 
+[[bin]]
+name = "pgmoneta-mcp-inspector"
+path = "src/bin/inspector/main.rs"
+
 [dependencies]
 tokio = {version = "1", features = ["full"] }
 serde = { version = "1", features = ["derive"] }
@@ -61,10 +65,14 @@ serde_ini = "0.2.0"
 tracing-appender = "0.2.4"
 syslog-tracing = "0.3.1"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
-
+inquire = "0.9.4"
+treelog = { version = "0.0.6", features = ["arbitrary-json"] }
 [target.'cfg(windows)'.dependencies]
 winlog2 = "0.3.2"
 log = "0.4"
+
+[dev-dependencies]
+tempfile = "3.27.0"
 
 [[test]]
 name = "info_test"

--- a/doc/DEVELOPERS.md
+++ b/doc/DEVELOPERS.md
@@ -343,6 +343,48 @@ Parameter structs must derive:
 
 ---
 
+## MCP Inspector
+
+The `pgmoneta-mcp-inspector` is a command-line developer tool for testing and debugging the MCP server.
+It serves the same purpose as the [MCP Inspector](https://modelcontextprotocol.io/docs/tools/inspector), allowing you to list tools, call them, and inspect responses directly from the terminal.
+
+The built-in CLI inspector reads server connection details from a dedicated configuration file.
+
+Create `pgmoneta-mcp-inspector.conf`:
+
+```ini
+[inspector]
+url = http://localhost:8000/mcp
+timeout = 30
+```
+
+Run with the config file:
+
+```sh
+pgmoneta-mcp-inspector inspector -c pgmoneta-mcp-inspector.conf tool list
+```
+
+Example tool call:
+
+```sh
+pgmoneta-mcp-inspector inspector -c pgmoneta-mcp-inspector.conf tool call <tool_name_with_args> '{"key": "value"}'
+```
+
+```sh
+pgmoneta-mcp-inspector inspector -c pgmoneta-mcp-inspector.conf tool call <tool_name_without_args>
+```
+
+Interactive mode can be started explicitly or by running with no command:
+
+```sh
+pgmoneta-mcp-inspector interactive
+pgmoneta-mcp-inspector
+```
+
+For full CLI reference, see the **MCP Inspector** chapter.
+
+---
+
 ## Continuous Integration
 
 The project uses GitHub Actions for CI. The pipeline includes:

--- a/doc/manual/en/73-mcp-inspector.md
+++ b/doc/manual/en/73-mcp-inspector.md
@@ -1,0 +1,105 @@
+# pgmoneta-mcp-inspector
+
+## Inspector Configuration File
+
+The `inspector` command reads connection settings from a conf file.
+
+Default path:
+
+```text
+/etc/pgmoneta-mcp/pgmoneta-mcp-inspector.conf
+```
+
+Expected format:
+
+```ini
+[inspector]
+url = http://localhost:8000/mcp
+timeout = 30
+```
+
+## CLI Hierarchy Tree
+The following tree visualizes the entire command-line structure.
+
+```text
+pgmoneta-mcp-inspector
+│
+├── inspector (Connect to MCP server)
+│   ├── --conf -c <CONF>       (Optional: Inspector config path. Default: /etc/pgmoneta-mcp/pgmoneta-mcp-inspector.conf)
+│   │
+│   └── tool (Manage and execute MCP tools)
+│       ├── list (List all available tools on the server)
+│       │   └── --output -o <tree|json> (Default: tree)
+│       │
+│       └── call (Call a specific tool)
+│           ├── <NAME>              (Position 1: Tool name, e.g., get_backup_info)
+│           ├── <ARGS>              (Position 2: Strict JSON arguments. Default: "{}")
+│           ├── --file -f <PATH>    (Optional: Path file containing JSON arguments)
+│           └── --output -o <tree|json> (Default: tree)
+│
+├── interactive (Default) (launch interactive wizard/shell)
+│
+└── --help -h                  (Print help information. Available at any level for context-aware help)
+
+```
+---
+
+## Commands
+ Execute commands directly.
+
+### A. Inspector Example
+
+#### 1. Listing Tools
+
+```bash
+./pgmoneta-mcp-inspector inspector --conf <path_to_inspector_conf> tool list
+```
+
+#### 2. Calling a Tool
+
+```bash
+./pgmoneta-mcp-inspector inspector --conf <path_to_inspector_conf> tool call <tool_name_with_args> '{"key": "value"}'
+```
+```bash
+./pgmoneta-mcp-inspector inspector --conf <path_to_inspector_conf> tool call <tool_name_without_args>
+```
+
+> **Note 1:** The `-f` flag allows you to load data from any file. This is functionally identical to typing directly in the terminal.Max file size supported: **10 MB**
+> ```bash
+> ./pgmoneta-mcp-inspector inspector --conf <path_to_inspector_conf> tool call get_backup_info -f <path_to_args_file>
+> ```
+
+---
+
+## Interactive
+
+Built on the command line, that provides a smooth user experience and converting user input into commands and executing them. run it: 
+
+```bash
+./pgmoneta-mcp-inspector interactive
+```
+
+Or run with no command to enter interactive mode by default:
+
+```bash
+./pgmoneta-mcp-inspector
+```
+
+> **Note 1 (Strict JSON Inputs):** Because the wizard may assemble a JSON request from your inputs (like the `args` of the `call` tool), every value must be a valid JSON value:
+>
+> | Type | Rule | Example |
+> | :--- | :--- | :--- |
+> | String | Must be wrapped in double quotes | `"primary"` |
+> | Number | Enter directly | `123` |
+> | Boolean | Enter directly | `true` or `false` |
+> | Object | Enter full JSON object | `{"key": "value"}` |
+> | Array | Enter full JSON array | `["a", "b", "c"]` |
+> | Null | Enter null keyword | `null` |
+> | Empty (skip) | Leave blank — the key will not be sent | *(press Enter)* |
+
+> **Note 2 (`@path` Injection):** In any argument prompt, type @ followed by a file path to inject the file's content as the value. Max file size supported: **10 MB**.
+> ```
+> @anypath/file.txt
+> ```
+
+> **Note 3 :** You can press **Esc** or **Ctrl+C** during in the interactive wizard to cancel the current action and return to the main menu.

--- a/src/bin/inspector/interactive.rs
+++ b/src/bin/inspector/interactive.rs
@@ -1,0 +1,279 @@
+// Copyright (C) 2026 The pgmoneta community
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+use crate::{AppInspector, OutputFormat};
+use anyhow::{Result, anyhow, bail};
+use inquire::{Select, Text};
+use pgmoneta_mcp::utils::SafeFileReader;
+use std::collections::HashMap;
+
+pub trait InteractiveWizard {
+    #[allow(async_fn_in_trait)]
+    async fn run(&self) -> Result<()>;
+}
+
+/// Gracefully handles Inquire cancellations such as Esc or Ctrl+C
+macro_rules! prompt_or_cancel {
+    ($prompt_result:expr, $err_msg:expr) => {
+        match $prompt_result {
+            Ok(val) => val,
+            Err(inquire::InquireError::OperationCanceled)
+            | Err(inquire::InquireError::OperationInterrupted) => return Ok(None),
+            Err(e) => anyhow::bail!("{}: {}", $err_msg, e),
+        }
+    };
+}
+
+/// The main entry point for the interactive router.
+/// Displays a greeting and allows the user to select and launch the desired wizard module.
+pub async fn run_interactive_router() -> Result<()> {
+    let inspector_version = env!("CARGO_PKG_VERSION");
+    println!();
+    println!(
+        "Welcome to pgmoneta MCP Inspector Interactive Shell! v{}",
+        inspector_version
+    );
+    println!();
+
+    let options = vec!["Inspector", "Exit"];
+
+    loop {
+        let choice = Select::new("Select a module:", options.clone()).prompt();
+
+        match choice {
+            Ok("Inspector") => {
+                let wizard = InspectorWizard;
+                if let Err(e) = wizard.run().await {
+                    eprintln!("Error executing command: {}", e);
+                }
+            }
+            Ok("Exit")
+            | Err(inquire::InquireError::OperationCanceled)
+            | Err(inquire::InquireError::OperationInterrupted) => break,
+            Ok(_) => {}
+            Err(e) => anyhow::bail!("An error occurred: {}", e),
+        }
+    }
+    Ok(())
+}
+
+pub struct InspectorWizard;
+impl InteractiveWizard for InspectorWizard {
+    async fn run(&self) -> Result<()> {
+        let default_conf = "/etc/pgmoneta-mcp/pgmoneta-mcp-inspector.conf";
+        let prompt_text = format!(
+            "Enter configuration file path [default: {}] =",
+            default_conf
+        );
+
+        let conf_input = match Text::new(&prompt_text).prompt() {
+            Ok(val) => val,
+            Err(inquire::InquireError::OperationCanceled)
+            | Err(inquire::InquireError::OperationInterrupted) => return Ok(()),
+            Err(e) => anyhow::bail!("Configuration path input failed: {}", e),
+        };
+
+        let conf_path = if conf_input.trim().is_empty() {
+            default_conf.to_string()
+        } else {
+            conf_input.trim().to_string()
+        };
+
+        let app_inspector = AppInspector::connect(&conf_path).await?; // One single connection
+
+        if let Some((server_name, server_version, url)) = app_inspector.server_info() {
+            println!();
+            println!("  Connected to: {}", url);
+            println!("  Server: {} v{}", server_name, server_version);
+            println!();
+        }
+
+        let options = vec!["Tools", "Exit"];
+        loop {
+            let choice = Select::new("What would you like to manage?", options.clone()).prompt();
+
+            match choice {
+                Ok("Tools") => {
+                    if let Err(e) = PageTool::handle_tools(&app_inspector).await {
+                        eprintln!("Error: {}", e);
+                    }
+                }
+                Ok("Exit")
+                | Err(inquire::InquireError::OperationCanceled)
+                | Err(inquire::InquireError::OperationInterrupted) => break,
+                Ok(_) => continue,
+                Err(e) => bail!("An error occurred: {}", e),
+            }
+        }
+        app_inspector.cleanup().await?;
+        Ok(())
+    }
+}
+
+pub struct PageTool;
+impl PageTool {
+    pub async fn handle_tools(inspector: &AppInspector) -> Result<()> {
+        let options = vec!["List Tools", "Call Tool"];
+        let choice = match Select::new("What would you like to do with tools?", options).prompt() {
+            Ok(c) => c,
+            Err(inquire::InquireError::OperationCanceled)
+            | Err(inquire::InquireError::OperationInterrupted) => return Ok(()),
+            Err(e) => bail!("Selection failed: {}", e),
+        };
+
+        match choice {
+            "List Tools" => {
+                inspector.run_list_tools(&OutputFormat::Tree).await?;
+            }
+            "Call Tool" => {
+                let tools = inspector.list_tools().await?;
+
+                if tools.is_empty() {
+                    bail!("Notice: No tools are currently available on the server.");
+                }
+
+                let tool_names: Vec<String> = tools.iter().map(|t| t.name.to_string()).collect();
+
+                let name = match Select::new("Select a tool to call:", tool_names).prompt() {
+                    Ok(n) => n,
+                    Err(inquire::InquireError::OperationCanceled)
+                    | Err(inquire::InquireError::OperationInterrupted) => return Ok(()),
+                    Err(e) => bail!("Tool selection failed: {}", e),
+                };
+
+                let tool = tools
+                    .iter()
+                    .find(|t| t.name == name)
+                    .ok_or_else(|| anyhow!("Tool '{}' not found", name))?;
+
+                if let Some(args) = Self::build_calltool_args(&tool.input_schema)? {
+                    inspector
+                        .run_call_tool_raw(name, args, &OutputFormat::Tree)
+                        .await?;
+                }
+            }
+            _ => {}
+        }
+
+        Ok(())
+    }
+
+    /// Extracts the type, description, and formats a user prompt for a given schema property.
+    fn extract_property_info(
+        prop_name: &str,
+        prop_schema: &serde_json::Value,
+    ) -> (String, String, String) {
+        let prop_type = prop_schema
+            .get("type")
+            .and_then(|t| t.as_str())
+            .unwrap_or("unknown type");
+        let desc = prop_schema
+            .get("description")
+            .and_then(|d| d.as_str())
+            .unwrap_or("unknown description");
+
+        let short_desc = desc.chars().take(30).collect::<String>();
+        let prompt = format!("{} [{}] [{}] =", prop_name, prop_type, short_desc);
+
+        (prop_type.to_string(), desc.to_string(), prompt)
+    }
+
+    /// Interactively builds arguments for a tool call by prompting the user based on its JSON schema.
+    /// Supports `@`-prefixed file paths to load values from local files.
+    fn build_calltool_args(
+        schema: &serde_json::Map<String, serde_json::Value>,
+    ) -> Result<Option<HashMap<String, serde_json::Value>>> {
+        let mut args = HashMap::new();
+        let props = schema
+            .get("properties")
+            .and_then(|v| v.as_object())
+            .ok_or_else(|| anyhow!("Tool schema missing properties"))?;
+
+        for (prop_name, prop_schema) in props {
+            let (_, _, prompt) = Self::extract_property_info(prop_name, prop_schema);
+
+            let v = prompt_or_cancel!(Text::new(&prompt).prompt(), "Input failed");
+
+            if !v.trim().is_empty() {
+                let content = if let Some(path) = v.trim().strip_prefix('@') {
+                    SafeFileReader::new()
+                        .max_size(10 * 1024 * 1024)
+                        .read(path)?
+                } else {
+                    v
+                };
+
+                let parsed =
+                    serde_json::from_str(&content).map_err(|e| anyhow!("Invalid JSON: {}", e))?;
+                args.insert(prop_name.clone(), parsed);
+            }
+        }
+        Ok(Some(args))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn test_extract_property_info_scenarios() {
+        // Test with type and description
+        let schema_full = json!({"type": "string", "description": "The server name"});
+        let (ptype, desc, prompt) = PageTool::extract_property_info("server", &schema_full);
+        assert_eq!(ptype, "string");
+        assert_eq!(desc, "The server name");
+        assert!(prompt.contains("server"));
+        assert!(prompt.contains("[string]"));
+        assert!(prompt.contains("[The server name]"));
+
+        // Test missing type
+        let schema_no_type = json!({"description": "Some description"});
+        let (ptype, _, _) = PageTool::extract_property_info("field", &schema_no_type);
+        assert_eq!(ptype, "unknown type");
+
+        // Test missing description
+        let schema_no_desc = json!({"type": "integer"});
+        let (_, desc, _) = PageTool::extract_property_info("field", &schema_no_desc);
+        assert_eq!(desc, "unknown description");
+
+        // Test long description truncated
+        let long_desc =
+            "This is a very long description that should be truncated to thirty characters";
+        let schema_long = json!({"type": "string", "description": long_desc});
+        let (_, _, prompt) = PageTool::extract_property_info("field", &schema_long);
+        let short: String = long_desc.chars().take(30).collect();
+        assert!(prompt.contains(&short));
+        assert!(!prompt.contains(long_desc));
+    }
+
+    #[test]
+    fn test_build_calltool_args_scenarios() {
+        // Test missing properties
+        let schema_missing: serde_json::Map<String, serde_json::Value> = serde_json::Map::new();
+        let result_missing = PageTool::build_calltool_args(&schema_missing);
+        assert!(result_missing.is_err());
+        assert!(format!("{:?}", result_missing.unwrap_err()).contains("missing properties"));
+
+        // Test empty properties
+        let mut schema_empty = serde_json::Map::new();
+        schema_empty.insert("properties".to_string(), json!({}));
+        let result_empty = PageTool::build_calltool_args(&schema_empty);
+        assert!(result_empty.is_ok());
+        let args = result_empty.unwrap().unwrap();
+        assert!(args.is_empty());
+    }
+}

--- a/src/bin/inspector/main.rs
+++ b/src/bin/inspector/main.rs
@@ -1,0 +1,422 @@
+// Copyright (C) 2026 The pgmoneta community
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+pub mod interactive;
+
+use anyhow::{Result, anyhow, bail};
+use clap::{Args, Parser, Subcommand};
+use interactive::run_interactive_router;
+use pgmoneta_mcp::mcp_client::McpClient;
+use pgmoneta_mcp::utils::SafeFileReader;
+use rmcp::model::{CallToolResult, Tool};
+use serde::Serialize;
+use std::collections::HashMap;
+use treelog::{Tree, config::RenderConfig, renderer::write_tree_with_config};
+
+#[derive(Debug, Parser)]
+#[command(
+    name = "pgmoneta-mcp-inspector",
+    about = "Model Context Protocol (MCP) inspector for pgmoneta, a backup/restore tool for PostgreSQL",
+    version
+)]
+pub struct Cli {
+    #[command(subcommand)]
+    pub command: Option<McpCli>,
+}
+
+#[derive(Subcommand, Debug, Clone)]
+pub enum McpCli {
+    /// Inspector operations (connect to MCP server)
+    Inspector {
+        /// Path to pgmoneta MCP inspector configuration file
+        #[arg(
+            short = 'c',
+            long,
+            default_value = "/etc/pgmoneta-mcp/pgmoneta-mcp-inspector.conf"
+        )]
+        conf: String,
+
+        #[command(subcommand)]
+        action: InspectorCommands,
+    },
+
+    /// Launch the interactive wizard
+    Interactive,
+}
+
+#[derive(Subcommand, Debug, Clone)]
+pub enum InspectorCommands {
+    /// Manage and execute tools provided by the MCP Server
+    Tool {
+        #[command(subcommand)]
+        action: ToolCommands,
+    },
+}
+
+#[derive(Subcommand, Debug, Clone)]
+pub enum ToolCommands {
+    /// List all available tools on the MCP server
+    List {
+        #[command(flatten)]
+        print_opts: PrintArgs,
+    },
+
+    /// Call a specific tool on the MCP server
+    Call {
+        #[command(flatten)]
+        call_args: CallArgs,
+
+        #[command(flatten)]
+        print_opts: PrintArgs,
+    },
+}
+
+#[derive(Args, Debug, Clone)]
+pub struct CallArgs {
+    /// Name of the tool to call
+    pub name: String,
+
+    /// Optional path to a JSON file containing the arguments
+    #[arg(short = 'f', long = "file")]
+    pub file: Option<String>,
+
+    /// JSON arguments for the tool (Strict JSON format)
+    #[arg(default_value = "{}")]
+    pub args: String,
+}
+
+#[derive(Args, Debug, Clone)]
+pub struct PrintArgs {
+    /// Output format for responses
+    #[arg(short = 'o', long, value_enum, default_value_t = OutputFormat::Tree)]
+    pub output: OutputFormat,
+}
+
+#[derive(Debug, Clone, clap::ValueEnum, PartialEq)]
+pub enum OutputFormat {
+    /// Print response as an ASCII tree
+    Tree,
+    /// Print response as raw JSON
+    Json,
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let args = Cli::parse();
+
+    let cmd = args.command.unwrap_or(McpCli::Interactive);
+
+    match cmd {
+        McpCli::Interactive => {
+            run_interactive_router().await?;
+        }
+        McpCli::Inspector { conf, action } => {
+            let app = AppInspector::connect(&conf).await?;
+
+            match action {
+                InspectorCommands::Tool {
+                    action: tool_action,
+                } => match tool_action {
+                    ToolCommands::List { print_opts } => {
+                        app.run_list_tools(&print_opts.output).await?;
+                    }
+                    ToolCommands::Call {
+                        call_args,
+                        print_opts,
+                    } => {
+                        app.run_call_tool(&call_args, &print_opts.output).await?;
+                    }
+                },
+            }
+
+            app.cleanup().await?;
+        }
+    }
+
+    Ok(())
+}
+
+pub struct AppInspector {
+    client: McpClient,
+}
+impl AppInspector {
+    pub async fn connect(conf_path: &str) -> Result<Self> {
+        let config = pgmoneta_mcp::configuration::load_inspector_configuration(conf_path)?;
+        let client = McpClient::connect(&config.url, config.timeout).await?;
+        Ok(Self { client })
+    }
+
+    pub async fn cleanup(self) -> Result<()> {
+        self.client.cleanup().await?;
+        Ok(())
+    }
+
+    pub fn server_info(&self) -> Option<(&str, &str, &str)> {
+        self.client.server_info()
+    }
+
+    pub async fn list_tools(&self) -> Result<Vec<Tool>> {
+        self.client.list_tools().await
+    }
+
+    pub async fn call_tool(
+        &self,
+        name: String,
+        args: HashMap<String, serde_json::Value>,
+    ) -> Result<CallToolResult> {
+        self.client.call_tool(name, args).await
+    }
+
+    pub async fn run_list_tools(&self, format: &OutputFormat) -> Result<()> {
+        let tools = self.list_tools().await?;
+        let output = Self::format_response(&tools, format)?;
+        println!("{}", output);
+        Ok(())
+    }
+
+    pub async fn run_call_tool(&self, args: &CallArgs, format: &OutputFormat) -> Result<()> {
+        let map_args = Self::parse_call_args(args)?;
+        self.run_call_tool_raw(args.name.clone(), map_args, format)
+            .await
+    }
+
+    pub async fn run_call_tool_raw(
+        &self,
+        name: String,
+        args: HashMap<String, serde_json::Value>,
+        format: &OutputFormat,
+    ) -> Result<()> {
+        let result = self.call_tool(name, args).await?;
+        let output = Self::format_response(&result, format)?;
+        println!("{}", output);
+        Ok(())
+    }
+
+    fn format_response<T: Serialize>(data: &T, format: &OutputFormat) -> Result<String> {
+        println!();
+        let value =
+            serde_json::to_value(data).map_err(|e| anyhow!("Error serializing data: {:?}", e))?;
+        let value = Self::deep_decode(value);
+
+        match format {
+            OutputFormat::Json => serde_json::to_string_pretty(&value)
+                .map_err(|e| anyhow!("Error serializing pretty json: {:?}", e)),
+            OutputFormat::Tree => match serde_json::to_string(&value) {
+                Ok(compact_json) => match Tree::from_arbitrary_json(&compact_json) {
+                    Ok(tree) => {
+                        let mut output = String::new();
+                        let config = RenderConfig::default();
+                        if write_tree_with_config(&mut output, &tree, &config).is_ok() {
+                            Ok(output)
+                        } else {
+                            bail!("Failed to format tree output via treelog")
+                        }
+                    }
+                    Err(e) => bail!("Error parsing arbitrary JSON into tree: {:?}", e),
+                },
+                Err(e) => bail!("Error compacting data for tree: {:?}", e),
+            },
+        }
+    }
+
+    fn parse_call_args(call_args: &CallArgs) -> Result<HashMap<String, serde_json::Value>> {
+        if let Some(file_path) = &call_args.file {
+            let content = SafeFileReader::new()
+                .max_size(10 * 1024 * 1024)
+                .read(file_path)?;
+            serde_json::from_str(&content)
+                .map_err(|e| anyhow!("Invalid JSON in file '{}': {}", file_path, e))
+        } else {
+            let args_trimmed = call_args.args.trim();
+            if args_trimmed.is_empty() || args_trimmed == "{}" {
+                Ok(HashMap::new())
+            } else if args_trimmed.starts_with('{') {
+                serde_json::from_str(args_trimmed)
+                    .map_err(|e| anyhow!("Invalid JSON arguments provided: {}", e))
+            } else {
+                bail!("Invalid format. Use strict JSON '{{\"key\": \"val\"}}' or -f <PATH>");
+            }
+        }
+    }
+
+    fn deep_decode(v: serde_json::Value) -> serde_json::Value {
+        match v {
+            serde_json::Value::String(mut s) => {
+                if let Ok(inner) = serde_json::from_str::<serde_json::Value>(&s) {
+                    Self::deep_decode(inner)
+                } else {
+                    if s.len() > 100
+                        && let Some((idx, _)) = s.char_indices().nth(100)
+                    {
+                        s.truncate(idx);
+                        s.push_str("...");
+                    }
+                    serde_json::Value::String(s)
+                }
+            }
+            serde_json::Value::Array(arr) => {
+                serde_json::Value::Array(arr.into_iter().map(Self::deep_decode).collect())
+            }
+            serde_json::Value::Object(map) => serde_json::Value::Object(
+                map.into_iter()
+                    .map(|(k, v)| (k, Self::deep_decode(v)))
+                    .collect(),
+            ),
+            other => other,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn make_call_args(name: &str, args: &str, file: Option<&str>) -> CallArgs {
+        CallArgs {
+            name: name.to_string(),
+            args: args.to_string(),
+            file: file.map(|f| f.to_string()),
+        }
+    }
+
+    #[test]
+    fn test_parse_empty_or_whitespace() {
+        // Test empty braces
+        let call_args = make_call_args("tool", "{}", None);
+        let result = AppInspector::parse_call_args(&call_args).unwrap();
+        assert!(result.is_empty());
+
+        // Test empty string
+        let call_args = make_call_args("tool", "", None);
+        let result = AppInspector::parse_call_args(&call_args).unwrap();
+        assert!(result.is_empty());
+
+        // Test whitespace only
+        let call_args = make_call_args("tool", "   ", None);
+        let result = AppInspector::parse_call_args(&call_args).unwrap();
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_parse_valid_json() {
+        // Test single key
+        let call_args = make_call_args("tool", r#"{"server":"s1"}"#, None);
+        let result = AppInspector::parse_call_args(&call_args).unwrap();
+        assert_eq!(result.len(), 1);
+        assert_eq!(result.get("server").unwrap(), "s1");
+
+        // Test multiple keys
+        let call_args = make_call_args("tool", r#"{"server":"s1","backup":"b1"}"#, None);
+        let result = AppInspector::parse_call_args(&call_args).unwrap();
+        assert_eq!(result.len(), 2);
+        assert_eq!(result.get("server").unwrap(), "s1");
+        assert_eq!(result.get("backup").unwrap(), "b1");
+    }
+
+    #[test]
+    fn test_parse_invalid_json() {
+        // Test not json
+        let call_args = make_call_args("tool", "not json", None);
+        let result = AppInspector::parse_call_args(&call_args);
+        assert!(result.is_err());
+
+        // Test missing brace
+        let call_args = make_call_args("tool", r#"{"key": "val""#, None);
+        let result = AppInspector::parse_call_args(&call_args);
+        assert!(result.is_err());
+
+        // Test invalid inside JSON
+        let call_args = make_call_args("tool", r#"{"key: unquoted_value}"#, None);
+        let result = AppInspector::parse_call_args(&call_args);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_format_response_formats() {
+        let data = json!({"name": "test_tool", "status": "ok"});
+
+        // Test JSON format
+        let result_json = AppInspector::format_response(&data, &OutputFormat::Json);
+        assert!(result_json.is_ok());
+
+        // Test Tree format
+        let result_tree = AppInspector::format_response(&data, &OutputFormat::Tree);
+        assert!(result_tree.is_ok());
+    }
+
+    #[test]
+    fn test_format_response_data_types() {
+        // Nested JSON
+        let nested_data = json!({
+            "tool": {
+                "name": "get_backup_info",
+                "params": {
+                    "server": "primary",
+                    "backup": "latest"
+                }
+            },
+            "status": "success"
+        });
+        assert!(AppInspector::format_response(&nested_data, &OutputFormat::Json).is_ok());
+        assert!(AppInspector::format_response(&nested_data, &OutputFormat::Tree).is_ok());
+
+        // Empty array
+        let empty_data: Vec<String> = vec![];
+        assert!(AppInspector::format_response(&empty_data, &OutputFormat::Json).is_ok());
+        assert!(AppInspector::format_response(&empty_data, &OutputFormat::Tree).is_ok());
+
+        // Large payload
+        let large_data = json!({
+            "field1": "value1",
+            "field2": "value2",
+            "field3": "value3",
+            "field4": 12345,
+            "field5": true,
+            "field6": null,
+            "field7": [1, 2, 3],
+            "field8": {"nested": "object"}
+        });
+        assert!(AppInspector::format_response(&large_data, &OutputFormat::Json).is_ok());
+        assert!(AppInspector::format_response(&large_data, &OutputFormat::Tree).is_ok());
+    }
+
+    #[test]
+    fn test_deep_decode_scenarios() {
+        // 1. Embedded JSON extracting
+        let val_embedded = json!("{\"status\": \"ok\", \"count\": 5}");
+        let decoded1 = AppInspector::deep_decode(val_embedded);
+        assert_eq!(decoded1, json!({"status": "ok", "count": 5}));
+
+        // 2. Double-encoded recursive unpacking
+        let inner = json!({"status": "ok"}).to_string();
+        let val_double = json!(inner);
+        let decoded2 = AppInspector::deep_decode(val_double);
+        assert_eq!(decoded2, json!({"status": "ok"}));
+
+        // 3. Deeply nested Array/Object decoding
+        let nested = json!(["normal_string", "{\"nested_key\": \"nested_val\"}"]);
+        let decoded3 = AppInspector::deep_decode(nested);
+        assert_eq!(
+            decoded3,
+            json!(["normal_string", {"nested_key": "nested_val"}])
+        );
+
+        // 4. Invalid JSON fallback (it remains a string)
+        let invalid_json = json!("{\"broken_key\": \"val\"");
+        let decoded_invalid = AppInspector::deep_decode(invalid_json.clone());
+        assert_eq!(decoded_invalid, invalid_json);
+    }
+}

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -125,6 +125,23 @@ pub struct LlmConfiguration {
     pub max_tool_rounds: usize,
 }
 
+/// Configuration properties for the inspector.
+///
+/// This corresponds to the `[inspector]` section in the inspector configuration file.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct InspectorConfiguration {
+    /// The URL of the MCP server.
+    pub url: String,
+    /// Connection timeout in seconds. Default: 30.
+    #[serde(default = "default_timeout")]
+    pub timeout: u64,
+}
+
+#[derive(Deserialize)]
+struct InspectorConfRoot {
+    pub inspector: InspectorConfiguration,
+}
+
 /// Loads the main configuration and user configuration from the specified file paths.
 ///
 /// The files are parsed as INI format and deserialized into the [`Configuration`] struct.
@@ -174,6 +191,31 @@ pub fn load_user_configuration(user_path: &str) -> anyhow::Result<UserConf> {
             e
         )
     })
+}
+
+/// Loads only the inspector configuration from the specified file path.
+///
+/// # Arguments
+///
+/// * `inspector_path` - The file path to the inspector configuration file.
+///
+/// # Returns
+///
+/// Returns a parsed [`InspectorConfiguration`] object, or an error if the file cannot be read or parsed.
+pub fn load_inspector_configuration(
+    inspector_path: &str,
+) -> anyhow::Result<InspectorConfiguration> {
+    let conf = Config::builder()
+        .add_source(config::File::with_name(inspector_path).format(FileFormat::Ini))
+        .build()?;
+    let root = conf.try_deserialize::<InspectorConfRoot>().map_err(|e| {
+        anyhow!(
+            "Error parsing inspector configuration at path {}: {:?}",
+            inspector_path,
+            e
+        )
+    })?;
+    Ok(root.inspector)
 }
 
 fn default_port() -> i32 {
@@ -245,4 +287,8 @@ fn default_compression() -> String {
 
 fn default_encryption() -> String {
     "aes_256_gcm".to_string()
+}
+
+fn default_timeout() -> u64 {
+    30
 }

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -191,8 +191,11 @@ impl Default for PgmonetaHandler {
 impl ServerHandler for PgmonetaHandler {
     /// Provides the MCP initialization capabilities and metadata for this server.
     fn get_info(&self) -> ServerInfo {
+        let pkg_name = env!("CARGO_PKG_NAME");
+        let pkg_version = env!("CARGO_PKG_VERSION");
+
         ServerInfo::new(ServerCapabilities::builder().enable_tools().build())
-            .with_server_info(Implementation::from_build_env())
+            .with_server_info(Implementation::new(pkg_name, pkg_version))
             .with_instructions("This server provides capabilities to interact with pgmoneta, a backup/restore tool for PostgreSQL.")
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,5 +36,6 @@ pub mod llm;
 
 mod client;
 pub mod logging;
+pub mod mcp_client;
 pub mod security;
 pub mod utils;

--- a/src/mcp_client.rs
+++ b/src/mcp_client.rs
@@ -1,0 +1,109 @@
+// Copyright (C) 2026 The pgmoneta community
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+use rmcp::model::Tool;
+use rmcp::model::{CallToolRequestParams, CallToolResult};
+use rmcp::service::RunningService;
+use rmcp::transport::streamable_http_client::StreamableHttpClientTransport;
+use rmcp::{RoleClient, ServiceExt};
+use std::collections::HashMap;
+use std::time::Duration;
+use tokio::time::timeout;
+
+/// The main client interface for communicating with the pgmoneta MCP server.
+pub struct McpClient {
+    session: RunningService<RoleClient, ()>,
+    timeout: Duration,
+    url: String,
+}
+
+impl McpClient {
+    /// Connects to the MCP server at the given URL with a specified timeout
+    pub async fn connect(url: &str, timeout_secs: u64) -> anyhow::Result<Self> {
+        let timeout_duration = Duration::from_secs(timeout_secs);
+        let transport = StreamableHttpClientTransport::from_uri(url);
+        let session = timeout(timeout_duration, ().serve(transport))
+            .await
+            .map_err(|_| {
+                anyhow::anyhow!("Connection timed out after {} seconds", timeout_secs)
+            })??;
+        Ok(Self {
+            session,
+            timeout: timeout_duration,
+            url: url.to_string(),
+        })
+    }
+
+    /// Lists all available tools from the MCP server
+    pub async fn list_tools(&self) -> anyhow::Result<Vec<Tool>> {
+        let result = timeout(self.timeout, self.session.list_tools(None))
+            .await
+            .map_err(|_| anyhow::anyhow!("list_tools timed out"))??;
+        Ok(result.tools)
+    }
+
+    /// Calls a specific tool with the provided arguments
+    pub async fn call_tool(
+        &self,
+        name: String,
+        args: HashMap<String, serde_json::Value>,
+    ) -> anyhow::Result<CallToolResult> {
+        let request = CallToolRequestParams::new(name).with_arguments(args.into_iter().collect());
+        let result = timeout(self.timeout, self.session.call_tool(request))
+            .await
+            .map_err(|_| anyhow::anyhow!("call_tool timed out"))??;
+        Ok(result)
+    }
+
+    /// Returns the server's name, version, and the connected URL.
+    pub fn server_info(&self) -> Option<(&str, &str, &str)> {
+        self.session.peer_info().map(|info| {
+            (
+                info.server_info.name.as_str(),
+                info.server_info.version.as_str(),
+                self.url.as_str(),
+            )
+        })
+    }
+
+    /// Cleanly closes the MCP session
+    pub async fn cleanup(self) -> anyhow::Result<()> {
+        self.session.cancel().await?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_connect_scenarios() {
+        // Test invalid URL
+        let result = McpClient::connect("not-a-url", 1).await;
+        assert!(result.is_err());
+
+        // Test timeout zero
+        let result = McpClient::connect("http://192.0.2.1:1234", 0).await;
+        match result {
+            Err(e) => assert_eq!(e.to_string(), "Connection timed out after 0 seconds"),
+            Ok(_) => panic!("Expected an error, but got Ok"),
+        }
+
+        // Test empty URL
+        let result = McpClient::connect("", 1).await;
+        assert!(result.is_err());
+    }
+}

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -13,8 +13,18 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
+use anyhow::{Result, bail};
+use std::path::{Path, PathBuf};
+
 /// Provides general-purpose helper functions for the application.
 pub struct Utility;
+
+/// A configurable safe file reader with security validations.
+pub struct SafeFileReader {
+    max_size: Option<u64>,
+    allowed_extensions: Option<Vec<String>>,
+    allowed_base_dir: Option<PathBuf>,
+}
 
 impl Utility {
     /// Formats a raw byte count into a human-readable file size string.
@@ -45,5 +55,189 @@ impl Utility {
         } else {
             format!("{:.2} TB", size as f64 / TB as f64)
         }
+    }
+}
+
+impl SafeFileReader {
+    pub fn new() -> Self {
+        Self {
+            max_size: None,
+            allowed_extensions: None,
+            allowed_base_dir: None,
+        }
+    }
+
+    pub fn max_size(mut self, size: u64) -> Self {
+        self.max_size = Some(size);
+        self
+    }
+
+    pub fn allowed_extensions(mut self, extensions: Vec<&str>) -> Self {
+        self.allowed_extensions = Some(extensions.iter().map(|e| e.to_lowercase()).collect());
+        self
+    }
+
+    pub fn allowed_base_dir(mut self, dir: &str) -> Self {
+        self.allowed_base_dir = Some(PathBuf::from(dir));
+        self
+    }
+
+    pub fn read(&self, file_path: &str) -> Result<String> {
+        let path = Path::new(file_path)
+            .canonicalize()
+            .map_err(|e| anyhow::anyhow!("Invalid file path '{}': {}", file_path, e))?;
+
+        // Check: is it a file?
+        if !path.is_file() {
+            bail!("'{}' is not a file", file_path);
+        }
+
+        // Check: allowed extensions
+        if let Some(ref allowed) = self.allowed_extensions {
+            let ext = path
+                .extension()
+                .and_then(|e| e.to_str())
+                .map(|e| e.to_lowercase())
+                .unwrap_or_default();
+
+            if !allowed.contains(&ext) {
+                bail!(
+                    "File '{}' has extension '.{}', but only [{}] are allowed",
+                    file_path,
+                    ext,
+                    allowed.join(", ")
+                );
+            }
+        }
+
+        // Check: allowed base directory
+        if let Some(ref base_dir) = self.allowed_base_dir {
+            let canonical_base = base_dir.canonicalize().map_err(|e| {
+                anyhow::anyhow!("Invalid base directory '{}': {}", base_dir.display(), e)
+            })?;
+
+            if !path.starts_with(&canonical_base) {
+                bail!(
+                    "Access denied: '{}' is outside the allowed directory '{}'",
+                    file_path,
+                    canonical_base.display()
+                );
+            }
+        }
+
+        // Check: file size
+        if let Some(max) = self.max_size {
+            let metadata = std::fs::metadata(&path)
+                .map_err(|e| anyhow::anyhow!("Cannot access '{}': {}", file_path, e))?;
+
+            if metadata.len() > max {
+                bail!(
+                    "File '{}' is too large ({}). Maximum allowed size is {}",
+                    file_path,
+                    Utility::format_file_size(metadata.len()),
+                    Utility::format_file_size(max)
+                );
+            }
+        }
+
+        std::fs::read_to_string(&path)
+            .map_err(|e| anyhow::anyhow!("Failed to read '{}': {}", path.display(), e))
+    }
+}
+
+impl Default for SafeFileReader {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    #[test]
+    fn test_read_file_valid() {
+        // Test JSON file
+        let mut tmp_json = tempfile::NamedTempFile::new().unwrap();
+        write!(tmp_json, r#"{{"server":"s1"}}"#).unwrap();
+        let path_json = tmp_json.path().to_str().unwrap();
+
+        let reader = SafeFileReader::new();
+        let result_json = reader.read(path_json).unwrap();
+        assert_eq!(result_json, r#"{"server":"s1"}"#);
+
+        // Test plain text file
+        let mut tmp_text = tempfile::NamedTempFile::new().unwrap();
+        write!(tmp_text, "just some plain text data").unwrap();
+        let path_text = tmp_text.path().to_str().unwrap();
+
+        let result_text = reader.read(path_text).unwrap();
+        assert_eq!(result_text, "just some plain text data");
+    }
+
+    #[test]
+    fn test_read_file_too_large() {
+        let mut tmp = tempfile::NamedTempFile::new().unwrap();
+        write!(tmp, "hello world").unwrap(); // 11 bytes
+        let path = tmp.path().to_str().unwrap();
+
+        let reader = SafeFileReader::new().max_size(5);
+        let result = reader.read(path);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("too large"));
+    }
+
+    #[test]
+    fn test_allowed_extensions() {
+        // Test valid extension
+        let mut tmp_valid = tempfile::Builder::new().suffix(".json").tempfile().unwrap();
+        write!(tmp_valid, r#"{{"server":"s1"}}"#).unwrap();
+        let path_valid = tmp_valid.path().to_str().unwrap();
+
+        let reader = SafeFileReader::new().allowed_extensions(vec!["json", "yaml"]);
+        let result_valid = reader.read(path_valid).unwrap();
+        assert_eq!(result_valid, r#"{"server":"s1"}"#);
+
+        // Test invalid extension
+        let mut tmp_invalid = tempfile::Builder::new().suffix(".txt").tempfile().unwrap();
+        write!(tmp_invalid, "some text").unwrap();
+        let path_invalid = tmp_invalid.path().to_str().unwrap();
+
+        let reader_invalid = SafeFileReader::new().allowed_extensions(vec!["json", "yaml"]);
+        let result_invalid = reader_invalid.read(path_invalid);
+        assert!(result_invalid.is_err());
+        assert!(
+            result_invalid
+                .unwrap_err()
+                .to_string()
+                .contains("only [json, yaml] are allowed")
+        );
+    }
+
+    #[test]
+    fn test_allowed_base_dir() {
+        // Test valid base dir
+        let tmp_dir = tempfile::tempdir().unwrap();
+        let file_path = tmp_dir.path().join("test.json");
+        let mut file = std::fs::File::create(&file_path).unwrap();
+        write!(file, r#"{{"server":"s1"}}"#).unwrap();
+
+        let reader = SafeFileReader::new().allowed_base_dir(tmp_dir.path().to_str().unwrap());
+        let result = reader.read(file_path.to_str().unwrap()).unwrap();
+        assert_eq!(result, r#"{"server":"s1"}"#);
+
+        // Test invalid base dir
+        let other_dir = tempfile::tempdir().unwrap();
+        let reader_invalid =
+            SafeFileReader::new().allowed_base_dir(other_dir.path().to_str().unwrap());
+        let result_invalid = reader_invalid.read(file_path.to_str().unwrap());
+        assert!(result_invalid.is_err());
+        assert!(
+            result_invalid
+                .unwrap_err()
+                .to_string()
+                .contains("Access denied")
+        );
     }
 }


### PR DESCRIPTION
Fixes #53

Hi @jesperpedersen,

I had already been experimenting with this idea while working on improving the MCP workflow, and it fits well with the goals of Issue #53. I created a dedicated interactive REPL client (`pgmoneta-mcp-repl`) to talk directly to the MCP server.

**Features**

- Interactive Prompt (`pgtmcp>`)
- Implemented a true REPL experience
- Persistent command history  
- Arrow-key navigation  
- Integrated `shlex` and `clap` to safely process user input.

**Usage**


```bash
./pgmoneta-mcp-repl --url http://localhost:8000/mcp
pgtmcp> help
pgtmcp> list-tools
pgtmcp> call-tool <tool_name> '{"param1": "value1", "param2": "value2"}'
pgtmcp> exit
```

structure of the code is designed so that others can add new MCP-related features (such as resources or prompts) without breaking the existing implementation.