### PR TITLE
[#52] Add mode command support

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -15,6 +15,7 @@
 
 mod conf;
 mod info;
+mod mode;
 mod retention;
 mod shutdown;
 

--- a/src/client/mode.rs
+++ b/src/client/mode.rs
@@ -1,0 +1,40 @@
+// Copyright (C) 2026 The pgmoneta community
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+use super::PgmonetaClient;
+use crate::constant::Command;
+use serde::Serialize;
+
+#[derive(Serialize, Clone, Debug)]
+struct ModeRequest {
+    #[serde(rename = "Server")]
+    server: String,
+    #[serde(rename = "Action")]
+    action: String,
+}
+
+impl PgmonetaClient {
+    pub async fn request_mode(
+        username: &str,
+        server: &str,
+        action: &str,
+    ) -> anyhow::Result<String> {
+        let request = ModeRequest {
+            server: server.to_string(),
+            action: action.to_string(),
+        };
+        Self::forward_request(username, Command::MODE, request).await
+    }
+}

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -16,6 +16,7 @@
 pub mod conf;
 pub mod hello;
 pub mod info;
+pub mod mode;
 pub mod retention;
 pub mod shutdown;
 
@@ -59,6 +60,7 @@ impl PgmonetaHandler {
             .with_async_tool::<conf::ConfLsTool>()
             .with_async_tool::<conf::ConfGetTool>()
             .with_async_tool::<conf::ConfSetTool>()
+            .with_async_tool::<mode::SetModeTool>()
     }
 }
 

--- a/src/handler/mode.rs
+++ b/src/handler/mode.rs
@@ -1,0 +1,142 @@
+// Copyright (C) 2026 The pgmoneta community
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+use std::borrow::Cow;
+use std::sync::Arc;
+
+use super::PgmonetaHandler;
+use crate::client::PgmonetaClient;
+use rmcp::ErrorData as McpError;
+use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
+use rmcp::model::JsonObject;
+use rmcp::schemars;
+
+#[derive(Debug, Default, serde::Deserialize, schemars::JsonSchema)]
+pub struct ModeRequest {
+    pub username: String,
+    pub server: String,
+    pub action: String,
+}
+
+/// Tool for switching a server between online and offline mode.
+pub struct SetModeTool;
+
+impl ToolBase for SetModeTool {
+    type Parameter = ModeRequest;
+    type Output = String;
+    type Error = McpError;
+
+    fn name() -> Cow<'static, str> {
+        "set_mode".into()
+    }
+
+    fn description() -> Option<Cow<'static, str>> {
+        Some(
+            "Switch a pgmoneta server between online and offline mode. \
+            The action must be either \"online\" or \"offline\". \
+            The username has to be one of the pgmoneta admins to be able to access pgmoneta"
+                .into(),
+        )
+    }
+
+    // input_schema is NOT overridden — the default generates the correct JSON schema
+    // automatically from `type Parameter = ModeRequest` via its JsonSchema derive.
+
+    // output_schema must be overridden to return None because our Output type is String
+    // (dynamically-translated JSON), and the MCP spec requires output schema root type
+    // to be 'object', which String does not satisfy.
+    fn output_schema() -> Option<Arc<JsonObject>> {
+        None
+    }
+}
+
+impl AsyncTool<PgmonetaHandler> for SetModeTool {
+    async fn invoke(_service: &PgmonetaHandler, request: ModeRequest) -> Result<String, McpError> {
+        let result: String =
+            PgmonetaClient::request_mode(&request.username, &request.server, &request.action)
+                .await
+                .map_err(|e| {
+                    McpError::internal_error(format!("Failed to switch server mode: {:?}", e), None)
+                })?;
+        PgmonetaHandler::generate_call_tool_result_string(&result)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::constant::{Command, ManagementError};
+    use rmcp::handler::server::router::tool::ToolBase;
+
+    #[test]
+    fn test_set_mode_tool_metadata() {
+        assert_eq!(SetModeTool::name(), "set_mode");
+        let desc = SetModeTool::description();
+        assert!(desc.is_some());
+        assert!(desc.unwrap().contains("online"));
+    }
+
+    #[test]
+    fn test_parse_mode_success_response() {
+        let response = r#"{"Outcome": {"Command": 24, "Status": "OK"}, "Server": "primary", "Mode": "online"}"#;
+        let result = PgmonetaHandler::_parse_and_check_result(response);
+        assert!(result.is_ok());
+        let map = result.unwrap();
+        assert!(map.contains_key("Outcome"));
+        assert!(map.contains_key("Server"));
+    }
+
+    #[test]
+    fn test_parse_mode_error_response() {
+        let response = r#"{"Outcome": {"Command": 24, "Error": 2800}}"#;
+        let result = PgmonetaHandler::_parse_and_check_result(response);
+        assert!(result.is_ok());
+        let map = result.unwrap();
+        assert!(map.contains_key("Outcome"));
+    }
+
+    #[test]
+    fn test_parse_mode_missing_outcome() {
+        let response = r#"{"Server": "primary", "Mode": "online"}"#;
+        let result = PgmonetaHandler::_parse_and_check_result(response);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_translate_mode_error_noserver() {
+        let error_msg = ManagementError::translate_error_enum(2800);
+        assert_eq!(error_msg, "Mode: no server");
+    }
+
+    #[test]
+    fn test_translate_mode_error_unknown_action() {
+        let error_msg = ManagementError::translate_error_enum(2805);
+        assert_eq!(error_msg, "Mode: unknown action");
+    }
+
+    #[test]
+    fn test_translate_mode_command() {
+        let result = Command::translate_command_enum(24);
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), "mode");
+    }
+
+    #[test]
+    fn test_generate_mode_result() {
+        let response = r#"{"Outcome": {"Command": 24, "Status": "OK"}, "Server": "primary", "Mode": "online"}"#;
+        let result = PgmonetaHandler::generate_call_tool_result_string(response);
+        assert!(result.is_ok());
+    }
+}

--- a/tests/mode_test.rs
+++ b/tests/mode_test.rs
@@ -1,0 +1,79 @@
+// Copyright (C) 2026 The pgmoneta community
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+use pgmoneta_mcp::handler::PgmonetaHandler;
+use pgmoneta_mcp::handler::mode::{ModeRequest, SetModeTool};
+use rmcp::handler::server::router::tool::AsyncTool;
+use serde_json::Value;
+
+mod common;
+
+#[tokio::test]
+#[ignore = "requires pgmoneta stack (see test/check.sh and full-test CI job)"]
+async fn set_mode_online_test() {
+    common::init_config();
+
+    let handler = PgmonetaHandler::new();
+    let request = ModeRequest {
+        username: "backup_user".to_string(),
+        server: "primary".to_string(),
+        action: "online".to_string(),
+    };
+
+    let response = SetModeTool::invoke(&handler, request)
+        .await
+        .expect("set_mode should succeed");
+
+    let json: Value = serde_json::from_str(&response).expect("response should be valid json");
+
+    if let Some(outcome) = json.get("Outcome") {
+        if let Some(command) = outcome.get("Command") {
+            assert_eq!(command, "mode");
+        } else {
+            panic!("Command field missing in Outcome");
+        }
+    } else {
+        panic!("Outcome field missing");
+    };
+}
+
+#[tokio::test]
+#[ignore = "requires pgmoneta stack (see test/check.sh and full-test CI job)"]
+async fn set_mode_offline_test() {
+    common::init_config();
+
+    let handler = PgmonetaHandler::new();
+    let request = ModeRequest {
+        username: "backup_user".to_string(),
+        server: "primary".to_string(),
+        action: "offline".to_string(),
+    };
+
+    let response = SetModeTool::invoke(&handler, request)
+        .await
+        .expect("set_mode should succeed");
+
+    let json: Value = serde_json::from_str(&response).expect("response should be valid json");
+
+    if let Some(outcome) = json.get("Outcome") {
+        if let Some(command) = outcome.get("Command") {
+            assert_eq!(command, "mode");
+        } else {
+            panic!("Command field missing in Outcome");
+        }
+    } else {
+        panic!("Outcome field missing");
+    };
+}


### PR DESCRIPTION
# Summary
  - Add set_mode MCP tool to switch pgmoneta servers between online and offline mode
  - Implement client module (client/mode.rs) and handler module (handler/mode.rs)
  - Add 7 unit tests for mode command parsing, translation, and error handling

# Closes #52 