### PR TITLE
[#43] Upgrade rmcp to v1 and refactor tool registration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,7 +20,7 @@ checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -263,6 +263,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.0",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -392,6 +403,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -706,6 +726,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.0",
  "wasip2",
  "wasip3",
 ]
@@ -1086,9 +1107,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.182"
+version = "0.2.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
+checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
 name = "litemap"
@@ -1184,7 +1205,6 @@ dependencies = [
  "getrandom 0.2.17",
  "http",
  "rand 0.8.5",
- "reqwest",
  "serde",
  "serde_json",
  "serde_path_to_error",
@@ -1367,7 +1387,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "opaque-debug",
  "universal-hash",
 ]
@@ -1458,6 +1478,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.0",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1494,6 +1525,12 @@ checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
 
 [[package]]
 name = "redox_syscall"
@@ -1543,9 +1580,9 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reqwest"
-version = "0.12.28"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -1562,7 +1599,6 @@ dependencies = [
  "pin-project-lite",
  "serde",
  "serde_json",
- "serde_urlencoded",
  "sync_wrapper",
  "tokio",
  "tokio-util",
@@ -1599,12 +1635,11 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "0.13.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1815dbc06c414d720f8bc1951eccd66bc99efc6376331f1e7093a119b3eb508"
+checksum = "d2cb14cb9278a12eae884c9f3c0cfeca2cc28f361211206424a1d7abed95f090"
 dependencies = [
  "async-trait",
- "axum",
  "base64 0.22.1",
  "bytes",
  "chrono",
@@ -1615,7 +1650,7 @@ dependencies = [
  "oauth2",
  "pastey",
  "pin-project-lite",
- "rand 0.9.2",
+ "rand 0.10.0",
  "reqwest",
  "rmcp-macros",
  "schemars",
@@ -1634,9 +1669,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "0.13.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11f0bc7008fa102e771a76c6d2c9b253be3f2baa5964e060464d038ae1cbc573"
+checksum = "6a02ea81d9482b07e1fe156ac7cf98b6823d51fb84531936a5e1cbb4eec31ad5"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -1867,7 +1902,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -2536,9 +2571,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-streams"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
 dependencies = [
  "futures-util",
  "js-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ path = "src/bin/admin.rs"
 [dependencies]
 tokio = {version = "1", features = ["full"] }
 serde = { version = "1", features = ["derive"] }
-rmcp = { version = "0.13", features = [
+rmcp = { version = "1", features = [
     "server",
     "macros",
     "client",

--- a/doc/DEVELOPERS.md
+++ b/doc/DEVELOPERS.md
@@ -11,6 +11,7 @@ It is intended for developers who want to build, test, debug, or extend the proj
 
 ## Prerequisites
 
+- Rust 1.85+
 - Rust toolchain (stable), preferably installed via [rustup](https://rustup.rs)
 - `cargo` (included with Rust)
 - `git`
@@ -141,6 +142,165 @@ VS Code users can debug using the **CodeLLDB** extension.
 The project uses the `tracing` ecosystem for logging.
 
 Logging is primarily configured via the configuration file.  
+
+---
+
+## Adding a New Tool
+
+The MCP server uses [rmcp](https://crates.io/crates/rmcp) v1's **trait-based tool system**. Each tool is a self-contained struct that defines its own name, description, parameters, and handler logic. Tools live in separate files under `src/handler/`.
+
+### Architecture
+
+```
+src/handler.rs              ← Router + shared helpers (parse, translate, serialize)
+src/handler/hello.rs        ← SayHelloTool (SyncTool)
+src/handler/info.rs         ← GetBackupInfoTool, ListBackupsTool (AsyncTool)
+src/handler/<new_tool>.rs   ← Your new tool goes here
+```
+
+`handler.rs` only needs two changes when adding a tool:
+1. `mod new_tool;` — declare the submodule
+2. `.with_async_tool::<new_tool::MyTool>()` — register it in the router
+
+Everything else (name, description, parameters, logic, tests) lives in the tool's own file.
+
+### Step-by-step
+
+#### 1. Create the tool file
+
+Create `src/handler/my_command.rs`:
+
+```rust
+use std::borrow::Cow;
+use std::sync::Arc;
+
+use super::PgmonetaHandler;
+use crate::client::PgmonetaClient;
+use rmcp::ErrorData as McpError;
+use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
+use rmcp::model::JsonObject;
+use rmcp::schemars;
+
+// Define the parameter struct with required derives
+#[derive(Debug, Default, serde::Deserialize, schemars::JsonSchema)]
+pub struct MyCommandRequest {
+    pub username: String,
+    pub server: String,
+}
+
+// Define the tool struct
+pub struct MyCommandTool;
+
+impl ToolBase for MyCommandTool {
+    type Parameter = MyCommandRequest;
+    type Output = String;
+    type Error = McpError;
+
+    fn name() -> Cow<'static, str> {
+        "my_command".into()
+    }
+
+    fn description() -> Option<Cow<'static, str>> {
+        Some("Description of what this tool does".into())
+    }
+
+    // input_schema is NOT overridden — the default generates the correct JSON schema
+    // automatically from `type Parameter` via its JsonSchema derive.
+
+    // output_schema must be overridden to return None because our Output type is String
+    // (dynamically-translated JSON), and the MCP spec requires output schema root type
+    // to be 'object', which String does not satisfy.
+    fn output_schema() -> Option<Arc<JsonObject>> {
+        None
+    }
+}
+
+impl AsyncTool<PgmonetaHandler> for MyCommandTool {
+    async fn invoke(
+        _service: &PgmonetaHandler,
+        request: MyCommandRequest,
+    ) -> Result<String, McpError> {
+        // Call pgmoneta via the client
+        let result: String = PgmonetaClient::request_my_command(
+            &request.username,
+            &request.server,
+        )
+        .await
+        .map_err(|e| {
+            McpError::internal_error(
+                format!("Failed to execute my_command: {:?}", e),
+                None,
+            )
+        })?;
+
+        // Use the shared pipeline to parse and translate the response
+        PgmonetaHandler::generate_call_tool_result_string(&result)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rmcp::handler::server::router::tool::ToolBase;
+
+    #[test]
+    fn test_my_command_tool_metadata() {
+        assert_eq!(MyCommandTool::name(), "my_command");
+        assert!(MyCommandTool::description().is_some());
+    }
+}
+```
+
+#### 2. Register the tool
+
+In `src/handler.rs`, add the module declaration and register the tool:
+
+```rust
+mod hello;
+mod info;
+mod my_command;  // ← add this
+
+// ...
+
+pub fn tool_router() -> ToolRouter<Self> {
+    ToolRouter::new()
+        .with_sync_tool::<hello::SayHelloTool>()
+        .with_async_tool::<info::GetBackupInfoTool>()
+        .with_async_tool::<info::ListBackupsTool>()
+        .with_async_tool::<my_command::MyCommandTool>()  // ← add this
+}
+```
+
+#### 3. Run checks
+
+```bash
+cargo fmt
+cargo build
+cargo test
+```
+
+### Key traits
+
+| Trait | Use when |
+|-------|----------|
+| `SyncTool<PgmonetaHandler>` | No async operations needed (e.g., `SayHelloTool`) |
+| `AsyncTool<PgmonetaHandler>` | Tool calls pgmoneta or does I/O (most tools) |
+
+### Shared response pipeline
+
+For tools that call pgmoneta, use `PgmonetaHandler::generate_call_tool_result_string(&raw_json)`. This method:
+1. Parses the raw JSON response
+2. Validates the `Outcome` field is present
+3. Translates numeric fields to human-readable formats (file sizes, LSNs, compression/encryption names)
+4. Returns the translated JSON as a `String`
+
+### Required derives for parameter structs
+
+Parameter structs must derive:
+- `Debug` — for error messages
+- `Default` — required by `ToolBase::Parameter` bound
+- `serde::Deserialize` — for JSON deserialization
+- `schemars::JsonSchema` — for auto-generated JSON schema
 
 ---
 

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -13,18 +13,15 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
+mod hello;
 mod info;
 
-use super::client::PgmonetaClient;
 use super::constant::*;
 use super::constant::{Command, Compression, Encryption};
 use crate::utils::Utility;
 use rmcp::{
-    ErrorData as McpError, RoleServer, ServerHandler,
-    handler::server::{router::tool::ToolRouter, wrapper::Parameters},
-    model::*,
-    service::RequestContext,
-    tool, tool_handler, tool_router,
+    ErrorData as McpError, RoleServer, ServerHandler, handler::server::router::tool::ToolRouter,
+    model::*, service::RequestContext, tool_handler,
 };
 use serde_json::Map;
 use serde_json::Value;
@@ -38,7 +35,6 @@ pub struct PgmonetaHandler {
     tool_router: ToolRouter<PgmonetaHandler>,
 }
 
-#[tool_router]
 impl PgmonetaHandler {
     /// Creates a new instance of the `PgmonetaHandler` with an initialized tool router.
     pub fn new() -> Self {
@@ -47,38 +43,12 @@ impl PgmonetaHandler {
         }
     }
 
-    /// Simple ping tool to verify the MCP server is responsive.
-    #[tool(description = "Say hello to the client")]
-    fn say_hello(&self) -> Result<CallToolResult, McpError> {
-        Ok(CallToolResult::success(vec![Content::text(
-            "Hello from pgmoneta MCP server!",
-        )]))
-    }
-
-    /// Tool for fetching detailed information about a specific backup.
-    #[tool(
-        description = "Get information of a backup using given backup ID and server name. \
-    \"newest\", \"latest\" or \"oldest\" are also accepted as backup identifier.\
-    The username has to be one of the pgmoneta admins to be able to access pgmoneta"
-    )]
-    async fn get_backup_info(
-        &self,
-        Parameters(args): Parameters<info::InfoRequest>,
-    ) -> Result<CallToolResult, McpError> {
-        let result = self._get_backup_info(args).await?;
-        Self::_generate_call_tool_result(&result)
-    }
-
-    /// Tool for listing available backups on a specified server.
-    #[tool(description = "List backups of a server. \
-        Specify asc or desc to determine the sorting order.\
-        The backups are sorted in ascending order if not specified.")]
-    async fn list_backups(
-        &self,
-        Parameters(args): Parameters<info::ListBackupsRequest>,
-    ) -> Result<CallToolResult, McpError> {
-        let result = self._list_backups(args).await?;
-        Self::_generate_call_tool_result(&result)
+    /// Builds the tool router by registering each tool via the trait-based API.
+    pub fn tool_router() -> ToolRouter<Self> {
+        ToolRouter::new()
+            .with_sync_tool::<hello::SayHelloTool>()
+            .with_async_tool::<info::GetBackupInfoTool>()
+            .with_async_tool::<info::ListBackupsTool>()
     }
 }
 
@@ -86,7 +56,7 @@ impl PgmonetaHandler {
     /// Parses the raw string response from pgmoneta into a JSON map.
     ///
     /// Ensures the response contains the required `Outcome` category key.
-    fn _parse_and_check_result(result: &str) -> Result<Map<String, Value>, McpError> {
+    pub(crate) fn _parse_and_check_result(result: &str) -> Result<Map<String, Value>, McpError> {
         let response: Map<String, Value> = serde_json::from_str(result).map_err(|e| {
             McpError::parse_error(format!("Failed to parse result {result}: {:?}", e), None)
         })?;
@@ -105,7 +75,7 @@ impl PgmonetaHandler {
     /// * Formatting byte counts into human-readable file sizes (e.g., KB, MB).
     /// * Converting LSNs (Log Sequence Numbers) into hex strings.
     /// * Translating numeric enum codes (Compression, Encryption, Error) into descriptive strings.
-    fn _translate_result<'a, M>(map: M) -> anyhow::Result<Map<String, Value>>
+    pub(crate) fn _translate_result<'a, M>(map: M) -> anyhow::Result<Map<String, Value>>
     where
         M: IntoIterator<Item = (&'a String, &'a Value)>,
     {
@@ -190,9 +160,9 @@ impl PgmonetaHandler {
         Ok(trans_res)
     }
 
-    /// Wraps the parsed and translated pgmoneta response into a standardized `CallToolResult`
-    /// that can be sent back to the MCP client.
-    fn _generate_call_tool_result(result: &str) -> Result<CallToolResult, McpError> {
+    /// Parses, translates, and serializes the pgmoneta response into a JSON string
+    /// suitable for returning as tool output.
+    pub(crate) fn generate_call_tool_result_string(result: &str) -> Result<String, McpError> {
         let res = Self::_parse_and_check_result(result)?;
         let trans_res = Self::_translate_result(&res).map_err(|e| {
             McpError::internal_error(
@@ -200,10 +170,9 @@ impl PgmonetaHandler {
                 None,
             )
         })?;
-        let trans_res_str = serde_json::to_string(&trans_res).map_err(|e| {
+        serde_json::to_string(&trans_res).map_err(|e| {
             McpError::internal_error(format!("Failed to serialize result: {:?}", e), None)
-        })?;
-        Ok(CallToolResult::success(vec![Content::text(trans_res_str)]))
+        })
     }
 }
 
@@ -217,20 +186,14 @@ impl Default for PgmonetaHandler {
 impl ServerHandler for PgmonetaHandler {
     /// Provides the MCP initialization capabilities and metadata for this server.
     fn get_info(&self) -> ServerInfo {
-        ServerInfo {
-            protocol_version: ProtocolVersion::V_2024_11_05,
-            capabilities: ServerCapabilities::builder()
-                .enable_tools()
-                .build(),
-            server_info: Implementation::from_build_env(),
-            instructions: Some("This server provides capabilities to interact with pgmoneta, a backup/restore tool for PostgreSQL.".to_string()),
-        }
+        ServerInfo::new(ServerCapabilities::builder().enable_tools().build())
+            .with_instructions("This server provides capabilities to interact with pgmoneta, a backup/restore tool for PostgreSQL.")
     }
 
     /// Handles the initial connection setup and handshake from an MCP client.
     async fn initialize(
         &self,
-        _request: InitializeRequestParam,
+        _request: InitializeRequestParams,
         context: RequestContext<RoleServer>,
     ) -> Result<InitializeResult, McpError> {
         if let Some(http_request_part) = context.extensions.get::<axum::http::request::Parts>() {
@@ -239,5 +202,60 @@ impl ServerHandler for PgmonetaHandler {
             tracing::info!(?initialize_headers, %initialize_uri, "initialize from http server");
         }
         Ok(self.get_info())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn test_parse_and_check_result_valid() {
+        let input = r#"{"Outcome": "success", "Server": "test"}"#;
+        let result = PgmonetaHandler::_parse_and_check_result(input);
+        assert!(result.is_ok());
+        let map = result.unwrap();
+        assert_eq!(map.get("Outcome").unwrap(), "success");
+        assert_eq!(map.get("Server").unwrap(), "test");
+    }
+
+    #[test]
+    fn test_parse_and_check_result_missing_outcome() {
+        let input = r#"{"Server": "test"}"#;
+        let result = PgmonetaHandler::_parse_and_check_result(input);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_parse_and_check_result_invalid_json() {
+        let input = "not valid json";
+        let result = PgmonetaHandler::_parse_and_check_result(input);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_translate_result_file_size() {
+        let mut map = Map::new();
+        map.insert("BackupSize".to_string(), json!(1048576));
+        map.insert("Server".to_string(), json!("test"));
+
+        let result = PgmonetaHandler::_translate_result(&map);
+        assert!(result.is_ok());
+        let translated = result.unwrap();
+        assert_eq!(translated.get("BackupSize").unwrap(), "1.00 MB");
+        assert_eq!(translated.get("Server").unwrap(), "test");
+    }
+
+    #[test]
+    fn test_generate_call_tool_result_string_valid() {
+        let input = r#"{"Outcome": "success", "BackupSize": 2048}"#;
+        let result = PgmonetaHandler::generate_call_tool_result_string(input);
+        assert!(result.is_ok());
+        let output = result.unwrap();
+        // The output should be a JSON string with translated fields
+        let parsed: Map<String, Value> = serde_json::from_str(&output).unwrap();
+        assert_eq!(parsed.get("Outcome").unwrap(), "success");
+        assert_eq!(parsed.get("BackupSize").unwrap(), "2.00 KB");
     }
 }

--- a/src/handler/hello.rs
+++ b/src/handler/hello.rs
@@ -1,0 +1,83 @@
+// Copyright (C) 2026 The pgmoneta community
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+use std::borrow::Cow;
+
+use super::PgmonetaHandler;
+use rmcp::ErrorData as McpError;
+use rmcp::handler::server::router::tool::{SyncTool, ToolBase};
+use rmcp::model::JsonObject;
+use std::sync::Arc;
+
+/// Simple ping tool to verify the MCP server is responsive.
+pub struct SayHelloTool;
+
+impl ToolBase for SayHelloTool {
+    type Parameter = ();
+    type Output = String;
+    type Error = McpError;
+
+    fn name() -> Cow<'static, str> {
+        "say_hello".into()
+    }
+
+    fn description() -> Option<Cow<'static, str>> {
+        Some("Say hello to the client".into())
+    }
+
+    // input_schema is overridden to return None because this tool takes no parameters.
+    fn input_schema() -> Option<Arc<JsonObject>> {
+        None
+    }
+
+    // output_schema is overridden to return None because our Output type is String,
+    // and the MCP spec requires output schema root type to be 'object'.
+    fn output_schema() -> Option<Arc<JsonObject>> {
+        None
+    }
+}
+
+impl SyncTool<PgmonetaHandler> for SayHelloTool {
+    fn invoke(_service: &PgmonetaHandler, _param: ()) -> Result<String, McpError> {
+        Ok("Hello from pgmoneta MCP server!".to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rmcp::handler::server::router::tool::{SyncTool, ToolBase};
+
+    #[test]
+    fn test_say_hello_tool() {
+        let handler = PgmonetaHandler::new();
+        let result = SayHelloTool::invoke(&handler, ());
+        assert!(result.is_ok());
+        assert_eq!(
+            result.unwrap(),
+            "Hello from pgmoneta MCP server!".to_string()
+        );
+    }
+
+    #[test]
+    fn test_say_hello_tool_metadata() {
+        assert_eq!(SayHelloTool::name(), "say_hello");
+        assert!(SayHelloTool::description().is_some());
+        assert_eq!(
+            SayHelloTool::description().unwrap(),
+            "Say hello to the client"
+        );
+    }
+}

--- a/src/handler/info.rs
+++ b/src/handler/info.rs
@@ -13,45 +13,147 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-use super::PgmonetaClient;
+use std::borrow::Cow;
+use std::sync::Arc;
+
 use super::PgmonetaHandler;
+use crate::client::PgmonetaClient;
 use crate::constant::Sort;
 use rmcp::ErrorData as McpError;
+use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
+use rmcp::model::JsonObject;
 use rmcp::schemars;
 
-#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+#[derive(Debug, Default, serde::Deserialize, schemars::JsonSchema)]
 pub struct InfoRequest {
     pub username: String,
     pub server: String,
     pub backup_id: String,
 }
 
-#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+#[derive(Debug, Default, serde::Deserialize, schemars::JsonSchema)]
 pub struct ListBackupsRequest {
     pub username: String,
     pub server: String,
     pub sort: Option<String>,
 }
 
-impl PgmonetaHandler {
-    pub(super) async fn _get_backup_info(&self, request: InfoRequest) -> Result<String, McpError> {
-        PgmonetaClient::request_backup_info(&request.username, &request.server, &request.backup_id)
-            .await
-            .map_err(|e| {
-                McpError::internal_error(
-                    format!("Failed to retrieve backup information: {:?}", e),
-                    None,
-                )
-            })
+/// Tool for fetching detailed information about a specific backup.
+pub struct GetBackupInfoTool;
+
+impl ToolBase for GetBackupInfoTool {
+    type Parameter = InfoRequest;
+    type Output = String;
+    type Error = McpError;
+
+    fn name() -> Cow<'static, str> {
+        "get_backup_info".into()
     }
 
-    pub(super) async fn _list_backups(
-        &self,
+    fn description() -> Option<Cow<'static, str>> {
+        Some(
+            "Get information of a backup using given backup ID and server name. \
+            \"newest\", \"latest\" or \"oldest\" are also accepted as backup identifier. \
+            The username has to be one of the pgmoneta admins to be able to access pgmoneta"
+                .into(),
+        )
+    }
+
+    // input_schema is NOT overridden — the default generates the correct JSON schema
+    // automatically from `type Parameter = InfoRequest` via its JsonSchema derive.
+
+    // output_schema must be overridden to return None because our Output type is String
+    // (dynamically-translated JSON), and the MCP spec requires output schema root type
+    // to be 'object', which String does not satisfy.
+    fn output_schema() -> Option<Arc<JsonObject>> {
+        None
+    }
+}
+
+impl AsyncTool<PgmonetaHandler> for GetBackupInfoTool {
+    async fn invoke(_service: &PgmonetaHandler, request: InfoRequest) -> Result<String, McpError> {
+        let result: String = PgmonetaClient::request_backup_info(
+            &request.username,
+            &request.server,
+            &request.backup_id,
+        )
+        .await
+        .map_err(|e| {
+            McpError::internal_error(
+                format!("Failed to retrieve backup information: {:?}", e),
+                None,
+            )
+        })?;
+        PgmonetaHandler::generate_call_tool_result_string(&result)
+    }
+}
+
+/// Tool for listing available backups on a specified server.
+pub struct ListBackupsTool;
+
+impl ToolBase for ListBackupsTool {
+    type Parameter = ListBackupsRequest;
+    type Output = String;
+    type Error = McpError;
+
+    fn name() -> Cow<'static, str> {
+        "list_backups".into()
+    }
+
+    fn description() -> Option<Cow<'static, str>> {
+        Some(
+            "List backups of a server. \
+            Specify asc or desc to determine the sorting order. \
+            The backups are sorted in ascending order if not specified."
+                .into(),
+        )
+    }
+
+    // input_schema is NOT overridden — the default generates the correct JSON schema
+    // automatically from `type Parameter = ListBackupsRequest` via its JsonSchema derive.
+
+    // output_schema must be overridden to return None because our Output type is String
+    // (dynamically-translated JSON), and the MCP spec requires output schema root type
+    // to be 'object', which String does not satisfy.
+    fn output_schema() -> Option<Arc<JsonObject>> {
+        None
+    }
+}
+
+impl AsyncTool<PgmonetaHandler> for ListBackupsTool {
+    async fn invoke(
+        _service: &PgmonetaHandler,
         request: ListBackupsRequest,
     ) -> Result<String, McpError> {
         let sort = request.sort.unwrap_or(Sort::ASC.to_string());
-        PgmonetaClient::request_list_backups(&request.username, &request.server, &sort)
-            .await
-            .map_err(|e| McpError::internal_error(format!("Failed to list backups: {:?}", e), None))
+        let result: String =
+            PgmonetaClient::request_list_backups(&request.username, &request.server, &sort)
+                .await
+                .map_err(|e| {
+                    McpError::internal_error(format!("Failed to list backups: {:?}", e), None)
+                })?;
+        PgmonetaHandler::generate_call_tool_result_string(&result)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rmcp::handler::server::router::tool::ToolBase;
+
+    #[test]
+    fn test_get_backup_info_tool_metadata() {
+        assert_eq!(GetBackupInfoTool::name(), "get_backup_info");
+        let desc = GetBackupInfoTool::description();
+        assert!(desc.is_some());
+        assert!(desc.unwrap().contains("backup"));
+    }
+
+    #[test]
+    fn test_list_backups_tool_metadata() {
+        assert_eq!(ListBackupsTool::name(), "list_backups");
+        let desc = ListBackupsTool::description();
+        assert!(desc.is_some());
+        assert!(desc.unwrap().contains("backups"));
     }
 }


### PR DESCRIPTION
Pump `rmcp` dependency to `v1.1.0` and refactors the MCP server to utilize the new trait-based tool system. This modernization improves code organization by decoupling individual tool logic from the central handler.
## Changes
- **Dependency Upgrade**: Updated `rmcp` from `0.13` to `1.1.0` in `Cargo.toml`.
- **Tool Architecture Refactoring**:
    - Extracted tool logic into dedicated structs implementing `SyncTool` and `AsyncTool` traits.
    - Moved `say_hello` tool to `src/handler/hello.rs`.
    - Moved `get_backup_info` and `list_backups` tools to `src/handler/info.rs`.
- **Handler Improvements**:
    - Refactored `PgmonetaHandler` to use `ToolRouter` for registration.
    - Updated `ServerHandler` implementation to comply with `rmcp` v1 API.
    - Exposed shared response parsing and translation logic for reuse by individual tools.
- **Documentation**: Added a "Adding a New Tool" section to `doc/DEVELOPERS.md` providing a step-by-step guide for the new architecture.
- **Testing**: Added comprehensive unit tests for tool metadata, invocation, and response translation.