### PR TITLE
[#51] Add shutdown command tool for pgmoneta

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -15,6 +15,7 @@
 
 mod info;
 mod retention;
+mod shutdown;
 
 use super::compression::CompressionUtil;
 use super::configuration::CONFIG;

--- a/src/client/shutdown.rs
+++ b/src/client/shutdown.rs
@@ -1,0 +1,78 @@
+// Copyright (C) 2026 The pgmoneta community
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+use super::PgmonetaClient;
+use crate::constant::Command;
+use serde::Serialize;
+
+#[derive(Serialize, Clone, Debug)]
+struct ShutdownRequest {
+    #[serde(rename = "Username")]
+    username: String,
+}
+
+impl PgmonetaClient {
+    /// Sends a shutdown command to the pgmoneta server.
+    ///
+    /// # Arguments
+    /// * `username` - The admin username making the request. Must be one of the pgmoneta admins configured in the system.
+    ///
+    /// # Returns
+    /// The raw string response from the pgmoneta server.
+    pub async fn request_shutdown(username: &str) -> anyhow::Result<String> {
+        let shutdown_request = ShutdownRequest {
+            username: username.to_string(),
+        };
+        Self::forward_request(username, Command::SHUTDOWN, shutdown_request).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_shutdown_request_serialization() {
+        let request = ShutdownRequest {
+            username: "admin".to_string(),
+        };
+        let json = serde_json::to_string(&request).unwrap();
+        assert!(json.contains("\"Username\""));
+        assert!(json.contains("\"admin\""));
+    }
+
+    #[test]
+    fn test_shutdown_command_constant() {
+        assert_eq!(Command::SHUTDOWN, 6);
+    }
+
+    #[test]
+    fn test_shutdown_request_structure() {
+        // Verify the request structure matches pgmoneta's expected format
+        let request = ShutdownRequest {
+            username: "backup_user".to_string(),
+        };
+
+        // Serialize and verify field naming
+        let json_str = serde_json::to_string(&request).unwrap();
+        let json: serde_json::Value = serde_json::from_str(&json_str).unwrap();
+
+        assert!(json.get("Username").is_some());
+        assert_eq!(
+            json.get("Username").unwrap().as_str().unwrap(),
+            "backup_user"
+        );
+    }
+}

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -16,6 +16,7 @@
 pub mod hello;
 pub mod info;
 pub mod retention;
+pub mod shutdown;
 
 use super::constant::*;
 use super::constant::{Command, Compression, Encryption};
@@ -52,6 +53,7 @@ impl PgmonetaHandler {
             .with_async_tool::<info::ListBackupsTool>()
             .with_async_tool::<retention::RetainBackupTool>()
             .with_async_tool::<retention::ExpungeBackupTool>()
+            .with_async_tool::<shutdown::ShutdownTool>()
     }
 }
 

--- a/src/handler/shutdown.rs
+++ b/src/handler/shutdown.rs
@@ -1,0 +1,103 @@
+// Copyright (C) 2026 The pgmoneta community
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+use std::borrow::Cow;
+use std::sync::Arc;
+
+use super::PgmonetaHandler;
+use crate::client::PgmonetaClient;
+use rmcp::ErrorData as McpError;
+use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
+use rmcp::model::JsonObject;
+use rmcp::schemars;
+
+#[derive(Debug, Default, serde::Deserialize, schemars::JsonSchema)]
+pub struct ShutdownRequest {
+    pub username: String,
+}
+
+/// Tool for shutting down the pgmoneta server.
+pub struct ShutdownTool;
+
+impl ToolBase for ShutdownTool {
+    type Parameter = ShutdownRequest;
+    type Output = String;
+    type Error = McpError;
+
+    fn name() -> Cow<'static, str> {
+        "shutdown".into()
+    }
+
+    fn description() -> Option<Cow<'static, str>> {
+        Some(
+            "Shutdown the pgmoneta server. \
+            The username has to be one of the pgmoneta admins to be able to perform this action. \
+            Note: After pgmoneta is shut down, subsequent backup-related tool calls will fail until pgmoneta is restarted."
+                .into(),
+        )
+    }
+
+    // output_schema must be overridden to return None because our Output type is String
+    // (dynamically-translated JSON), and the MCP spec requires output schema root type
+    // to be 'object', which String does not satisfy.
+    fn output_schema() -> Option<Arc<JsonObject>> {
+        None
+    }
+}
+
+impl AsyncTool<PgmonetaHandler> for ShutdownTool {
+    async fn invoke(
+        _service: &PgmonetaHandler,
+        request: ShutdownRequest,
+    ) -> Result<String, McpError> {
+        let result: String = PgmonetaClient::request_shutdown(&request.username)
+            .await
+            .map_err(|e| {
+                let error_msg = format!("{:?}", e);
+                if error_msg.contains("Connection refused")
+                    || error_msg.contains("connect")
+                    || error_msg.contains("os error 111")
+                {
+                    McpError::internal_error(
+                        format!(
+                            "Failed to connect to pgmoneta server: {}. \
+                             Hint: The pgmoneta server may not be running.",
+                            error_msg
+                        ),
+                        None,
+                    )
+                } else {
+                    McpError::internal_error(format!("Failed to shutdown pgmoneta: {:?}", e), None)
+                }
+            })?;
+        PgmonetaHandler::generate_call_tool_result_string(&result)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rmcp::handler::server::router::tool::ToolBase;
+
+    #[test]
+    fn test_shutdown_tool_metadata() {
+        assert_eq!(ShutdownTool::name(), "shutdown");
+        let desc = ShutdownTool::description();
+        assert!(desc.is_some());
+        let desc_str = desc.unwrap().to_lowercase();
+        assert!(desc_str.contains("shutdown"));
+        assert!(desc_str.contains("pgmoneta"));
+    }
+}


### PR DESCRIPTION
**What does this PR do?**
Implements the shutdown command tool for pgmoneta MCP server (resolves #51). The tool allows MCP clients to gracefully shut down the pgmoneta backup server.

**Behavior**
- Tool name: `shutdown`
- Sends `Command::SHUTDOWN` (code 6) to pgmoneta backend
- Requires admin username from configured pgmoneta admins
- MCP server process continues running (only pgmoneta backend is shut down)
- Returns translated response from pgmoneta

**Implementation**
- `src/handler/shutdown.rs` - MCP tool implementation with proper error handling
- `src/client/shutdown.rs` - Client request wrapper with serialization tests
- Tool registered in `PgmonetaHandler::tool_router()`

**Testing**
- 4 unit tests added covering:
  - Tool metadata (name, description)
  - Request serialization with correct JSON field naming
  - Command constant verification
  - Request structure validation
- All 15 tests pass
- `cargo fmt`, `cargo check`, `cargo clippy -- -D warnings` all pass

**Checklist**
- [x] Code follows existing patterns
- [x] Tests added and passing
- [x] `cargo fmt` applied
- [x] `cargo clippy` passes with no warnings
- [x] Commit message follows `[#issue] Description` format

**Notes**
- The tool description warns users that subsequent backup-related calls will fail after shutdown
- Connection errors after calling shutdown are expected (server terminates)