### PR TITLE
[#49] Support verify command in MCP server

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -20,6 +20,7 @@ mod info;
 mod mode;
 mod retention;
 mod shutdown;
+mod verify;
 
 use super::compression::CompressionUtil;
 use super::configuration::CONFIG;

--- a/src/client/verify.rs
+++ b/src/client/verify.rs
@@ -1,0 +1,42 @@
+// Copyright (C) 2026 The pgmoneta community
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+use super::PgmonetaClient;
+use crate::constant::Command;
+use serde::Serialize;
+
+/// Request payload for the verify command.
+#[derive(Serialize, Clone, Debug)]
+struct VerifyRequest {
+    #[serde(rename = "Server")]
+    server: String,
+    #[serde(rename = "Backup")]
+    backup: String,
+}
+
+impl PgmonetaClient {
+    /// Sends a verify command for a specific backup on a given server.
+    pub async fn request_verify(
+        username: &str,
+        server: &str,
+        backup: &str,
+    ) -> anyhow::Result<String> {
+        let verify_request = VerifyRequest {
+            server: server.to_string(),
+            backup: backup.to_string(),
+        };
+        Self::forward_request(username, Command::VERIFY, verify_request).await
+    }
+}

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -21,6 +21,7 @@ pub mod info;
 pub mod mode;
 pub mod retention;
 pub mod shutdown;
+pub mod verify;
 
 use super::constant::*;
 use super::constant::{Command, Compression, Encryption};
@@ -67,6 +68,7 @@ impl PgmonetaHandler {
             .with_async_tool::<compression::DecompressFileTool>()
             .with_async_tool::<encryption::EncryptFileTool>()
             .with_async_tool::<encryption::DecryptFileTool>()
+            .with_async_tool::<verify::VerifyBackupTool>()
     }
 }
 

--- a/src/handler/verify.rs
+++ b/src/handler/verify.rs
@@ -1,0 +1,92 @@
+// Copyright (C) 2026 The pgmoneta community
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+use std::borrow::Cow;
+use std::sync::Arc;
+
+use super::PgmonetaHandler;
+use crate::client::PgmonetaClient;
+use rmcp::ErrorData as McpError;
+use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
+use rmcp::model::JsonObject;
+use rmcp::schemars;
+
+#[derive(Debug, Default, serde::Deserialize, schemars::JsonSchema)]
+pub struct VerifyRequest {
+    pub username: String,
+    pub server: String,
+    pub backup_id: String,
+}
+
+/// Tool for verifying the integrity of a specific backup.
+pub struct VerifyBackupTool;
+
+impl ToolBase for VerifyBackupTool {
+    type Parameter = VerifyRequest;
+    type Output = String;
+    type Error = McpError;
+
+    fn name() -> Cow<'static, str> {
+        "verify_backup".into()
+    }
+
+    fn description() -> Option<Cow<'static, str>> {
+        Some(
+            "Verify the integrity of a backup using given backup ID and server name. \
+            \"newest\", \"latest\" or \"oldest\" are also accepted as backup identifier. \
+            The username has to be one of the pgmoneta admins to be able to access pgmoneta"
+                .into(),
+        )
+    }
+
+    // input_schema is NOT overridden — the default generates the correct JSON schema
+    // automatically from `type Parameter = VerifyRequest` via its JsonSchema derive.
+
+    // output_schema must be overridden to return None because our Output type is String
+    // (dynamically-translated JSON), and the MCP spec requires output schema root type
+    // to be 'object', which String does not satisfy.
+    fn output_schema() -> Option<Arc<JsonObject>> {
+        None
+    }
+}
+
+impl AsyncTool<PgmonetaHandler> for VerifyBackupTool {
+    async fn invoke(
+        _service: &PgmonetaHandler,
+        request: VerifyRequest,
+    ) -> Result<String, McpError> {
+        let result: String =
+            PgmonetaClient::request_verify(&request.username, &request.server, &request.backup_id)
+                .await
+                .map_err(|e| {
+                    McpError::internal_error(format!("Failed to verify backup: {:?}", e), None)
+                })?;
+        PgmonetaHandler::generate_call_tool_result_string(&result)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rmcp::handler::server::router::tool::ToolBase;
+
+    #[test]
+    fn test_verify_backup_tool_metadata() {
+        assert_eq!(VerifyBackupTool::name(), "verify_backup");
+        let desc = VerifyBackupTool::description();
+        assert!(desc.is_some());
+        assert!(desc.unwrap().contains("Verify"));
+    }
+}

--- a/tests/verify_test.rs
+++ b/tests/verify_test.rs
@@ -1,0 +1,48 @@
+// Copyright (C) 2026 The pgmoneta community
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+use pgmoneta_mcp::handler::PgmonetaHandler;
+use pgmoneta_mcp::handler::verify::{VerifyBackupTool, VerifyRequest};
+use rmcp::handler::server::router::tool::AsyncTool;
+use serde_json::Value;
+mod common;
+#[tokio::test]
+async fn verify_test() {
+    common::init_config();
+
+    let handler = PgmonetaHandler::new();
+    let verify_request = VerifyRequest {
+        username: "backup_user".to_string(),
+        server: "primary".to_string(),
+        backup_id: "newest".to_string(),
+    };
+
+    let response = VerifyBackupTool::invoke(&handler, verify_request)
+        .await
+        .expect("verify_backup should succeed");
+
+    let json: Value = serde_json::from_str(&response).expect("response should be valid json");
+
+    if let Some(header) = json.get("Header") {
+        if let Some(command) = header.get("Command") {
+            assert!(command.is_string(), "Command should be a string");
+            assert!(command == "verify", "Command should be 'verify'");
+        } else {
+            panic!("Command field missing in Header");
+        }
+    } else {
+        panic!("Header field missing");
+    };
+}


### PR DESCRIPTION
Closes #49 

Adds support for the [verify](cci:1://file:///Users/sakshii/pgmoneta_mcp-1/src/client/verify.rs:29:4-40:5) command in the MCP server. 

## Changes

- Added [src/client/verify.rs](cci:7://file:///Users/sakshii/pgmoneta_mcp-1/src/client/verify.rs:0:0-0:0) — wire-protocol request struct and [request_verify()](cci:1://file:///Users/sakshii/pgmoneta_mcp-1/src/client/verify.rs:29:4-40:5) for talking to pgmoneta
- Added [src/handler/verify.rs](cci:7://file:///Users/sakshii/pgmoneta_mcp-1/src/handler/verify.rs:0:0-0:0) — [VerifyBackupTool](cci:2://file:///Users/sakshii/pgmoneta_mcp-1/src/handler/verify.rs:33:0-33:28) implementing `ToolBase` + `AsyncTool`, with a unit test
- Registered the tool in the router ([src/handler.rs](cci:7://file:///Users/sakshii/pgmoneta_mcp-1/src/handler.rs:0:0-0:0))
- Added `mod verify` in both [src/client.rs](cci:7://file:///Users/sakshii/pgmoneta_mcp-1/src/client.rs:0:0-0:0) and [src/handler.rs](cci:7://file:///Users/sakshii/pgmoneta_mcp-1/src/handler.rs:0:0-0:0)

I kept verify in its own files rather than putting it inside [info.rs](cci:7://file:///Users/sakshii/pgmoneta_mcp-1/src/client/info.rs:0:0-0:0), since info already has [get_backup_info](cci:1://file:///Users/sakshii/pgmoneta_mcp-1/src/handler/info.rs:143:4-149:5) and [list_backups](cci:1://file:///Users/sakshii/pgmoneta_mcp-1/src/client/info.rs:48:4-58:5) and it felt cleaner to separate a different type of operation into its own module. This also matches how [hello](cci:1://file:///Users/sakshii/pgmoneta_mcp-1/src/handler/hello.rs:62:4-71:5) already has its own file.

## Testing

- `cargo build` — compiles fine
- `cargo test` — all 12 tests pass (including new [test_verify_backup_tool_metadata](cci:1://file:///Users/sakshii/pgmoneta_mcp-1/src/handler/verify.rs:84:4-90:5))
- `cargo fmt` — no issues
- `cargo clippy` — no warnings

The issue also mentions a memory leak on the pgmoneta (C) side when running verify. That's a separate problem in the upstream pgmoneta codebase and isn't addressed here, this PR only covers the MCP server support.
