### PR TITLE
[#79] implementation and documentation of RamaLama support

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -13,3 +13,4 @@ Mohammed Ashraf <mohashraf.eng@gmail.com>
 manascb1344 <zephop76593@gmail.com>
 Shikhar Soni <shikharish05@gmail.com>
 Sakshi Aggarwal <sakshiaggarwal2706@gmail.com>
+Sarthak Aneja <sarthakaneja260@gmail.com>

--- a/doc/LOCAL_LLM.md
+++ b/doc/LOCAL_LLM.md
@@ -8,7 +8,7 @@ implementation details.
 
 This guide covers:
 
-* Installing Ollama, llama.cpp, or vLLM
+* Installing Ollama, RamaLama, llama.cpp, or vLLM
 * Downloading and validating a model
 * Configuring the `[llm]` section in `pgmoneta-mcp.conf`
 
@@ -20,146 +20,112 @@ When choosing an LLM for **pgmoneta_mcp**, keep these key concepts in mind regar
 2. **Quantization**: Models are compressed ("quantized") to fit into consumer hardware. The default standard is **Q4** (4-bit quantization), which provides an excellent balance of speed, size, and reasoning quality.
 3. **Hardware Limits**: The model's listed file size indicates the *minimum* RAM needed simply to load its weights. Actual runtime usage will be 20-30% higher because the runtime allocates memory for context caching and inference buffers.
 
-## Ollama
-
-[Ollama](https://ollama.com) is the recommended provider for running open-source models locally.
-It provides a simple CLI and API for downloading, managing, and serving LLM models.
-
-### Install
-
-To install Ollama, follow instructions at [ollama.com/download](https://ollama.com/download).
-
-### Verify installation
-
-```
-ollama --version
-```
-
-### Start the Ollama server
-
-Ollama runs as a background service. Start it with
-
-```
-ollama serve
-```
-
-On Linux with systemd, it may already be running as a service after installation.
-
-Verify it is running
-
-```
-curl http://localhost:11434/
-```
-
-This should print `Ollama is running`.
-
-### Download models
-
-Models must be downloaded before they can be used. This is the only step that requires
-network access. Once downloaded, models are cached locally and work fully offline.
-
-* Pull a model
-
-    ```
-    ollama pull llama3.1
-    ```
-
-* List downloaded models
-
-    ```
-    ollama list
-    ```
-
-* Test a model
-
-    ```
-    ollama run llama3.1 "Hello, what can you do?"
-    ```
-
-### Recommended models
+### Model Compatibility Matrix
 
 The model must support **tool calling** (function calling) to work with pgmoneta MCP tools.
 
-| Model | Size | RAM Needed | Tool Calling | Notes |
-| :---- | :--- | :--------- | :----------- | :---- |
-| `llama3.1:8b` | ~4.7 GB | ~8 GB | Yes | **Default**. Best balance of capability and size |
-| `llama3.2:3b` | ~2.0 GB | ~4 GB | Yes | Lightweight option for limited hardware |
-| `qwen2.5:0.5b` | ~0.4 GB | ~1 GB | Yes | Extremely lightweight |
-| `qwen2.5:3b` | ~1.9 GB | ~4 GB | Yes | Great balance of speed and capabilities |
-| `qwen2.5:7b` | ~4.7 GB | ~8 GB | Yes | Excellent tool calling capabilities |
-| `mistral:7b` | ~4.1 GB | ~8 GB | Yes | Strong performance for open-source models |
-| `mixtral:8x7b` | ~26.0 GB | ~32 GB | Yes | High quality MoE model |
+| Model | Size | RAM Needed | Ollama | RamaLama | llama.cpp | vLLM | Notes |
+| :---- | :--- | :--------- | :----- | :------- | :-------- | :--- | :---- |
+| `granite-code` | ~5.0 GB | ~8 GB | Yes | Yes | Yes (GGUF) | Yes | **Recommended**. Built for coding and tool-calling |
+| `llama3.1:8b` | ~4.7 GB | ~8 GB | Yes | Yes | Yes (GGUF) | Yes | Best balance of capability and size |
+| `llama3.2:3b` | ~2.0 GB | ~4 GB | Yes | Yes | Yes (GGUF) | Yes | Lightweight option for limited hardware |
+| `qwen2.5:7b` | ~4.7 GB | ~8 GB | Yes | Yes | Yes (GGUF) | Yes | Excellent tool calling capabilities |
+| `mistral:7b` | ~4.1 GB | ~8 GB | Yes | Yes | Yes (GGUF) | Yes | Strong performance for open-source models |
 
-### Check tool support
+## Ollama
 
-You can verify that a model supports tool calling
+[Ollama](https://ollama.com) is the recommended provider for running open-source models locally. It provides a simple CLI and API for downloading, managing, and serving LLM models.
 
-```
-ollama show llama3.1
-```
+### Basic Setup (Rocky Linux 10)
 
-Look for `tools` in the capabilities list. Alternatively, query the API
+Install Ollama using the official script:
 
-```
-curl -s http://localhost:11434/api/show -d '{"model": "llama3.1"}' | grep capabilities
+```sh
+curl -fsSL https://ollama.com/install.sh | sh
 ```
 
-### Configuration
+Start the Ollama server as a background service:
 
-Add an `[llm]` section to your `pgmoneta-mcp.conf`:
+```sh
+ollama serve
+```
+
+Pull the recommended model:
+
+```sh
+ollama pull llama3.1:8b
+```
+
+### pgmoneta-mcp.conf Example
 
 ```ini
 [llm]
 provider = ollama
 endpoint = http://localhost:11434
-model = llama3.1
+model = llama3.1:8b
 max_tool_rounds = 10
 ```
 
 ## llama.cpp
 
-[llama.cpp](https://github.com/ggml-org/llama.cpp) provides direct control over hardware for running LLMs locally.
+[llama.cpp](https://github.com/ggml-org/llama.cpp) provides direct control over hardware and inference settings for running LLMs locally.
 
-### Install
+### Basic Setup (Rocky Linux 10)
 
-Download the `llama-server` binary from the [releases page](https://github.com/ggml-org/llama.cpp/releases).
+You must download the `llama-server` binary and the model file manually. 
 
-### Download models
-
-Download a `.gguf` model file from a source such as [Hugging Face](https://huggingface.co/). Search for a model name followed by `GGUF` to find the right repository (e.g. `Qwen2.5-7B-Instruct GGUF`).
-
-For **pgmoneta_mcp**, the following specific files are suitable choices:
-
-| Model file | Size | RAM needed | Notes |
-| :--------- | :--- | :--------- | :---- |
-| `Qwen2.5-7B-Instruct-Q4_K_M.gguf` | ~4.7 GB | ~8 GB | Strong tool calling accuracy |
-| `Qwen2.5-3B-Instruct-Q4_K_M.gguf` | ~1.9 GB | ~4 GB | Lower hardware requirement, some accuracy trade-off |
-| `Meta-Llama-3.1-8B-Instruct-Q4_K_M.gguf` | ~4.7 GB | ~8 GB | Widely used, good general reasoning |
-
-### Start the server
-
+```sh
+dnf install wget
 ```
+
+Download the latest `llama-server` from the [official releases](https://github.com/ggml-org/llama.cpp/releases), and download a `.gguf` model file from Hugging Face (e.g., `Meta-Llama-3.1-8B-Instruct-Q4_K_M.gguf`).
+
+Start the server:
+
+```sh
 llama-server \
   --model models/Meta-Llama-3.1-8B-Instruct-Q4_K_M.gguf \
   --port 8080 \
   --ctx-size 8192
 ```
 
-Verify it is running:
-
-```
-curl http://localhost:8080/health
-```
-
-### Configuration
-
-Add an `[llm]` section to your `pgmoneta-mcp.conf`:
+### pgmoneta-mcp.conf Example
 
 ```ini
 [llm]
 provider = llama.cpp
 endpoint = http://localhost:8080
-model = Meta-Llama-3.1-8B-Instruct-Q4_K_M
+model = Meta-Llama-3.1-8B-Instruct-Q4_K_M.gguf
+max_tool_rounds = 10
+```
+
+## RamaLama
+
+[RamaLama](https://ramalama.ai) is an open-source command-line interface and unified AI gateway that simplifies the deployment and inference of AI models using containerization (Podman or Docker).
+
+### Basic Setup (Rocky Linux 10)
+
+It is available natively on RPM-based distributions:
+
+```sh
+dnf install ramalama
+```
+
+RamaLama handles pulling models automatically. Start the server for the recommended model:
+
+```sh
+ramalama serve granite-code
+```
+
+The default endpoint is `http://localhost:8080`.
+
+### pgmoneta-mcp.conf Example
+
+```ini
+[llm]
+provider = ramalama
+endpoint = http://localhost:8080
+model = granite-code
 max_tool_rounds = 10
 ```
 
@@ -191,9 +157,7 @@ Verify it is running:
 curl http://localhost:8000/v1/models
 ```
 
-### Configuration
-
-Add an `[llm]` section to your `pgmoneta-mcp.conf`:
+### pgmoneta-mcp.conf Example
 
 ```ini
 [llm]
@@ -207,33 +171,38 @@ max_tool_rounds = 10
 
 | Property | Default | Required | Description |
 | :------- | :------ | :------- | :---------- |
-| provider |  | Yes | The LLM provider backend (`ollama`, `llama.cpp` or `vllm`) |
+| provider |  | Yes | The LLM provider backend (`ollama`, `llama.cpp`, `ramalama` or `vllm`) |
 | endpoint |  | Yes | The URL of the LLM inference server |
 | model |  | Yes | The model name to use for inference |
 | max_tool_rounds | 10 | No | Maximum tool-calling iterations per user prompt |
 
-### Quick verification
+## Quick verification
 
-1. Confirm your runtime is running:
+1. Confirm your LLM server is running:
 
-    For Ollama:
-    ```
-    curl http://localhost:11434/
-    ```
+For **Ollama**:
+```sh
+curl http://localhost:11434/
+```
 
-    For llama.cpp:
-    ```
-    curl http://localhost:8080/health
-    ```
+For **llama.cpp**:
+```sh
+curl http://localhost:8080/health
+```
 
-    For vLLM:
-    ```
-    curl http://localhost:8000/v1/models
-    ```
+For **RamaLama**:
+```sh
+curl http://localhost:8080/v1/models
+```
+
+For **vLLM**:
+```sh
+curl http://localhost:8000/v1/models
+```
 
 2. Start pgmoneta MCP with your config file:
 
-```
+```sh
 pgmoneta-mcp-server -c pgmoneta-mcp.conf -u pgmoneta-mcp-users.conf
 ```
 

--- a/doc/manual/en/20-llm.md
+++ b/doc/manual/en/20-llm.md
@@ -29,7 +29,7 @@ The overall flow looks like this:
 User prompt
     |
     v
-Local LLM runtime (Ollama or llama.cpp)
+Local LLM runtime (Ollama, RamaLama, vLLM or llama.cpp)
     |
     v
 pgmoneta_mcp tools
@@ -38,6 +38,19 @@ pgmoneta_mcp tools
 pgmoneta
 ```
 
+## Configuration
+
+Add an `[llm]` section to your `pgmoneta-mcp.conf` file to configure the runtime.
+
+### Configuration properties
+
+| Property | Default | Required | Description |
+| :------- | :------ | :------- | :---------- |
+| provider |  | Yes | The LLM provider backend (`ollama`, `llama.cpp`, `vLLM` or `ramalama`) |
+| endpoint |  | Yes | The URL of the LLM inference server |
+| model |  | Yes | The explicit model name to use for inference |
+| max_tool_rounds | 10 | No | Maximum tool-calling iterations per user prompt |
+
 ## Comparison
 
 When choosing a local runtime for **pgmoneta_mcp**, consider the following trade-offs
@@ -45,13 +58,13 @@ between ease of use and granular control.
 
 ### Runtime comparison
 
-| Feature | Ollama | llama.cpp | vLLM |
-| :--- | :--- | :--- | :--- |
-| **Installation** | Single binary / installer | Download or build binary | Python package (pip) |
-| **Model Management** | Built-in CLI (`pull`, `list`) | Manual download of `.gguf` files | Auto-downloads Safetensors |
-| **Ease of Use** | High (recommended for beginners) | Advanced (manual configuration) | Intermediate |
-| **Control** | Automatic hardware detection | Granular threading/GPU/RAM control | High-throughput optimizations |
-| **Performance** | Excellent (balanced) | Maximum (optimized for specific hardware) | Production-grade throughput |
+| Feature | Ollama | RamaLama | llama.cpp | vLLM |
+| :--- | :--- | :--- | :--- | :--- |
+| **Installation** | Single binary / installer | System package (dnf/pip) | Download or build binary | Python package (pip) |
+| **Model Management** | Built-in CLI (`pull`, `list`) | Automatic (OCI/HF registry) | Manual download of `.gguf` files | Auto-downloads Safetensors |
+| **Ease of Use** | High (recommended for beginners) | High (container-based) | Advanced (manual configuration) | Intermediate |
+| **Control** | Automatic hardware detection | Container-native isolation | Granular threading/GPU/RAM control | High-throughput optimizations |
+| **Performance** | Excellent (balanced) | Excellent (flexibility) | Maximum (optimized for specific hardware) | Production-grade throughput |
 
 ### Pros and Cons
 
@@ -99,7 +112,21 @@ between ease of use and granular control.
 * **Python dependency stack**: Installation pulls down heavy dependencies (like PyTorch and CUDA bindings) unless managed firmly via virtual environments or Docker.
 * **Lacks low-end quantization**: Not designed for hyper-compressed formats (like `Q2_K`) frequently used to squeeze models onto low-end hardware.
 
-## Recommended models
+**RamaLama**
+
+**Pros:**
+
+* **Container-native isolation**: Provides excellent reproducibility and environment security through Podman/Docker.
+* **Unified AI gateway**: Can pull models from any OCI-compliant registry or Hugging Face.
+* **Inference flexibility**: Supports multiple backends (like `vLLM` or `MLX`) through a single interface.
+* **Standardized**: Built from the ground up to be OpenAI-compatible.
+
+**Cons:**
+
+* **External dependency**: Requires a container engine to be installed and running.
+* **Container knowledge**: Slightly steeper learning curve for users unfamiliar with containers.
+
+## Model Selection
 
 When choosing an LLM for **pgmoneta_mcp**, keep these key concepts in mind regardless of which provider you choose:
 
@@ -108,7 +135,7 @@ When choosing an LLM for **pgmoneta_mcp**, keep these key concepts in mind regar
 
 ### Understanding model names
 
-Whether you are pulling a model via Ollama or downloading a `.gguf` file for `llama.cpp`, the model name usually encodes its size and compression level:
+Whether you are pulling a model via Ollama or RamaLama, or downloading a `.gguf` file for `llama.cpp`, the model name usually encodes its size and compression level:
 
 ``` text
 Qwen2.5-7B-Instruct-Q4_K_M
@@ -133,22 +160,20 @@ Start with a `7B` or `8B` model as a baseline. If the model repeatedly calls wro
 
 Models are compressed ("quantized") to reduce memory usage. The `Q` suffix indicates the compression level. `Q4_K_M` (4-bit quantization) is the recommended starting point for most setups — it uses roughly half the RAM of an uncompressed model with only a minor drop in reasoning quality.
 
-### Verified models
+### Model Compatibility Matrix
 
-The following models are verified for tool-calling performance. Sizes are based on the recommended Q4 quantization.
+The model must support **tool calling** (function calling) to work with pgmoneta MCP tools.
 
-| Model | Size (Disk) | RAM Needed | Performance |
-| :---- | :--- | :--------- | :---- |
-| Qwen 2.5 (0.5B) | ~0.4 GB | ~1 GB | Minimal footprint |
-| Llama 3.2 (3B) | ~2.0 GB | ~4 GB | Fast and lightweight |
-| Qwen 2.5 (3B) | ~1.9 GB | ~4 GB | High speed, decent quality |
-| Llama 3.1 (8B) | ~4.7 GB | ~8 GB | Balanced default choice |
-| Qwen 2.5 (7B) | ~4.7 GB | ~8 GB | Excellent tool-calling accuracy |
-| Mistral (7B) | ~4.1 GB | ~8 GB | Solid general-purpose model |
-| Mixtral (8x7B) | ~26.0 GB | ~32 GB | High quality, high hardware cost |
+| Model | Size | RAM Needed | Ollama | RamaLama | llama.cpp | vLLM | Notes |
+| :---- | :--- | :--------- | :----- | :------- | :-------- | :--- | :---- |
+| `granite-code` | ~5.0 GB | ~8 GB | Yes | Yes | Yes (GGUF) | Yes | **Recommended**. Built for coding and tool-calling |
+| `llama3.1:8b` | ~4.7 GB | ~8 GB | Yes | Yes | Yes (GGUF) | Yes | Best balance of capability and size |
+| `llama3.2:3b` | ~2.0 GB | ~4 GB | Yes | Yes | Yes (GGUF) | Yes | Lightweight option for limited hardware |
+| `qwen2.5:7b` | ~4.7 GB | ~8 GB | Yes | Yes | Yes (GGUF) | Yes | Excellent tool calling capabilities |
+| `mistral:7b` | ~4.1 GB | ~8 GB | Yes | Yes | Yes (GGUF) | Yes | Strong performance for open-source models |
 
-Examples of provider-specific model names can be found in the Ollama, llama.cpp, and vLLM sections below.
+Examples of provider-specific model names can be found in the Ollama, RamaLama, llama.cpp, and vLLM sections.
 
 ## Next step
 
-The next chapters document the recommended local runtimes: **Ollama**, **llama.cpp**, and **vLLM**, including installation, model setup, and configuration.
+The following sections document the recommended local runtimes: **Ollama**, **RamaLama**, **llama.cpp**, and **vLLM**, including installation, model setup, and configuration.

--- a/doc/manual/en/23-ramalama.md
+++ b/doc/manual/en/23-ramalama.md
@@ -1,0 +1,62 @@
+
+## RamaLama
+
+[RamaLama](https://ramalama.ai) is an open-source command-line interface and unified AI gateway that simplifies the deployment and inference of AI models using containerization (Podman or Docker). It provides an OpenAI-compatible REST API, making it easy to integrate with **pgmoneta_mcp**.
+
+Using `RamaLama` with `pgmoneta-mcp` allows you to leverage various runtimes (like `llama.cpp` or `vLLM`) through a single, stable interface.
+
+### Install
+
+To use `RamaLama`, you need to install the CLI. On Fedora and other RPM-based distributions, it is available via:
+
+``` sh
+dnf install ramalama
+```
+
+For other platforms, follow the instructions at [ramalama.ai](https://ramalama.ai).
+
+### Download models
+
+RamaLama automatically handles pulling models from registries like Hugging Face or OCI. You can pull a model explicitly:
+
+``` sh
+ramalama pull granite-code
+```
+
+### Start the server
+
+Start the RamaLama server using your chosen model. RamaLama will automatically run the model inside a container:
+
+``` sh
+ramalama serve granite-code
+```
+
+The default endpoint will be `http://localhost:8080`.
+
+### Configure pgmoneta_mcp
+
+Add or update the `[llm]` section in `pgmoneta-mcp.conf`:
+
+``` ini
+[llm]
+provider = ramalama
+endpoint = http://localhost:8080
+model = granite-3.0-8b-instruct
+max_tool_rounds = 10
+```
+
+### Quick verification
+
+Confirm the server is running:
+
+``` sh
+curl http://localhost:8080/v1/models
+```
+
+Start **pgmoneta_mcp**:
+
+``` sh
+pgmoneta-mcp-server -c pgmoneta-mcp.conf -u pgmoneta-mcp-users.conf
+```
+
+Open your MCP client and ask a question about your backups to verify end-to-end setup.

--- a/doc/manual/en/24-vllm.md
+++ b/doc/manual/en/24-vllm.md
@@ -19,7 +19,7 @@ For advanced installation methods (such as Docker or building from source), refe
 
 ### Download models
 
-Unlike `llama.cpp`, vLLM does not require you to manually hunt for `.gguf` files. It automatically pulls standard Hugging Face (Safetensor) model weights at runtime.
+vLLM does not require you to manually hunt for model files. It automatically pulls standard Hugging Face (Safetensor) model weights at runtime.
 
 You simply specify the Hugging Face repository ID (e.g., `ibm-granite/granite-3.0-8b-instruct`).
 

--- a/doc/manual/en/97-acknowledgement.md
+++ b/doc/manual/en/97-acknowledgement.md
@@ -18,6 +18,7 @@ Chen Shen <scisbeloved23@gmail.com>
 Nihal Kumar <collabwithnihal@gmail.com>
 Shikhar Soni <shikharish05@gmail.com>
 Sakshi Aggarwal <sakshiaggarwal2706@gmail.com>
+Sarthak Aneja <sarthakaneja260@gmail.com>
 ```
 
 ## Committers

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -234,7 +234,7 @@ fn normalize_configuration(mut conf: Configuration) -> anyhow::Result<Configurat
 
 fn validate_llm_provider(provider: &str) -> anyhow::Result<()> {
     match provider.to_lowercase().as_str() {
-        "ollama" | "llama.cpp" | "vllm" => Ok(()),
+        "ollama" | "llama.cpp" | "ramalama" | "vllm" => Ok(()),
         _ => Err(anyhow!("Unsupported LLM provider '{}'", provider)),
     }
 }

--- a/src/llm/mod.rs
+++ b/src/llm/mod.rs
@@ -87,7 +87,7 @@ pub enum LlmResponse {
 /// Trait defining the interface for an LLM client.
 ///
 /// Implementations of this trait handle communication with a specific LLM
-/// inference server (e.g., Ollama, vLLM, llama.cpp).
+/// inference server (e.g., Ollama, RamaLama, vLLM, or llama.cpp).
 #[allow(async_fn_in_trait)]
 pub trait LlmClient {
     /// Sends a conversation with available tool definitions to the LLM and returns its response.

--- a/src/llm/openai.rs
+++ b/src/llm/openai.rs
@@ -128,26 +128,39 @@ impl OpenAiClient {
     /// Checks whether the inference server is running and reachable.
     ///
     /// # Returns
-    /// `Ok(())` if the server responds to a basic `/health` endpoint, or an error.
+    /// `Ok(())` if the server responds to a basic `/health` or `/v1/models` endpoint, or an error.
     pub async fn health_check(&self) -> anyhow::Result<()> {
-        let url = format!("{}/health", self.endpoint);
-        let resp = self.http_client.get(&url).send().await.map_err(|e| {
-            anyhow!(
-                "Cannot reach {} at {}: {}",
-                self.provider_name,
-                self.endpoint,
-                e
-            )
-        })?;
+        let health_url = format!("{}/health", self.endpoint);
+        let resp = self.http_client.get(&health_url).send().await;
 
-        if !resp.status().is_success() {
-            return Err(anyhow!(
-                "{} health check failed with status {}",
-                self.provider_name,
-                resp.status()
-            ));
+        match resp {
+            Ok(r) if r.status().is_success() => Ok(()),
+            _ => {
+                // Try /v1/models as a fallback (RamaLama/vLLM)
+                let models_url = format!("{}/v1/models", self.endpoint);
+                let resp = self
+                    .http_client
+                    .get(&models_url)
+                    .send()
+                    .await
+                    .map_err(|e| {
+                        anyhow!(
+                            "Cannot reach {} at {}: {}",
+                            self.provider_name,
+                            self.endpoint,
+                            e
+                        )
+                    })?;
+
+                if !resp.status().is_success() {
+                    return Err(anyhow!(
+                        "{} health check failed (tried /health and /v1/models)",
+                        self.provider_name,
+                    ));
+                }
+                Ok(())
+            }
         }
-        Ok(())
     }
 
     /// Lists the models available on the server using the `/v1/models` endpoint.


### PR DESCRIPTION
Closes #79 

- Adds support for RamaLama as a local LLM provider
- Configuration support in `configuration.rs` and `mod.rs`
-  Added a new RamaLama chapter to the manual and a guide.
- Configured granite-code as the default model for RamaLama to ensure high-quality tool-calling
- Added a `Choosing a Local Runtime` guide comparing Ollama and RamaLama to help users select the right backend