### PR TITLE
Add interactive chat with multi-provider LLM support (Ollama, llama.cpp, Ramalama, vLLM), powered by rig

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -124,6 +124,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
 
 [[package]]
+name = "as-any"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0f477b951e452a0b6b4a10b53ccd569042d1d01729b519e02074a9c0958a063"
+
+[[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -145,6 +173,28 @@ name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "aws-lc-rs"
+version = "1.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.39.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83a25cf98105baa966497416dbd42565ce3a8cf8dbfd59803ec9ad46f3126399"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
 
 [[package]]
 name = "axum"
@@ -241,6 +291,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -268,15 +324,21 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.57"
+version = "1.2.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
+checksum = "b7a4d3ec6524d28a329fc53654bbadc9bdd7b0431f5d65f1a56ffb28a1ee5283"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
  "libc",
  "shlex",
 ]
+
+[[package]]
+name = "cesu8"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
 name = "cfg-if"
@@ -366,10 +428,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
 
 [[package]]
 name = "config"
@@ -389,6 +470,19 @@ dependencies = [
  "toml",
  "winnow",
  "yaml-rust2",
+]
+
+[[package]]
+name = "console"
+version = "0.15.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "unicode-width 0.2.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -430,6 +524,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "coolor"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "980c2afde4af43d6a05c5be738f9eae595cff86dce1f38f88b95058a98c027f3"
+dependencies = [
+ "crossterm",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -463,10 +586,77 @@ dependencies = [
 ]
 
 [[package]]
+name = "crokey"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04a63daf06a168535c74ab97cdba3ed4fa5d4f32cb36e437dcceb83d66854b7c"
+dependencies = [
+ "crokey-proc_macros",
+ "crossterm",
+ "once_cell",
+ "serde",
+ "strict",
+]
+
+[[package]]
+name = "crokey-proc_macros"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "847f11a14855fc490bd5d059821895c53e77eeb3c2b73ee3dded7ce77c93b231"
+dependencies = [
+ "crossterm",
+ "proc-macro2",
+ "quote",
+ "strict",
+ "syn",
+]
+
+[[package]]
+name = "crossbeam"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1137cd7e7fc0fb5d3c5a8678be38ec56e819125d8d7907411fe24ccb943faca8"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-epoch",
+ "crossbeam-queue",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -565,6 +755,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -593,6 +789,19 @@ dependencies = [
  "quote",
  "rustc_version",
  "syn",
+]
+
+[[package]]
+name = "dialoguer"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "658bce805d770f407bc62102fca7c2c64ceef2fbcb2b8bd19d2765ce093980de"
+dependencies = [
+ "console",
+ "shell-words",
+ "tempfile",
+ "thiserror 1.0.69",
+ "zeroize",
 ]
 
 [[package]]
@@ -636,10 +845,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
 name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "encoding_rs"
@@ -678,10 +899,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "fastrand"
-version = "2.3.0"
+name = "eventsource-stream"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "74fef4569247a5f429d9156b9d0a2599914385dd189c539334c625d8099d90ab"
+dependencies = [
+ "futures-core",
+ "nom",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "find-msvc-tools"
@@ -700,6 +932,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -713,6 +951,12 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures"
@@ -784,6 +1028,12 @@ name = "futures-task"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-timer"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
 
 [[package]]
 name = "futures-util"
@@ -870,6 +1120,31 @@ checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
 dependencies = [
  "opaque-debug",
  "polyval",
+]
+
+[[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
+name = "h2"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
 ]
 
 [[package]]
@@ -973,21 +1248,21 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
 dependencies = [
  "atomic-waker",
  "bytes",
  "futures-channel",
  "futures-core",
+ "h2",
  "http",
  "http-body",
  "httparse",
  "httpdate",
  "itoa",
  "pin-project-lite",
- "pin-utils",
  "smallvec",
  "tokio",
  "want",
@@ -1007,7 +1282,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots",
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]
@@ -1028,9 +1303,11 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "socket2",
+ "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
+ "windows-registry",
 ]
 
 [[package]]
@@ -1059,12 +1336,13 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
 dependencies = [
  "displaydoc",
  "potential_utf",
+ "utf8_iter",
  "yoke",
  "zerofrom",
  "zerovec",
@@ -1072,9 +1350,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -1085,9 +1363,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -1099,15 +1377,15 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
 
 [[package]]
 name = "icu_properties"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
 dependencies = [
  "icu_collections",
  "icu_locale_core",
@@ -1119,15 +1397,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
 
 [[package]]
 name = "icu_provider"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -1173,14 +1451,27 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "45a8a2b9cb3e0b0c1803dbb0758ffac5de2f425b23c28f518faabd9d805342ff"
 dependencies = [
  "equivalent",
  "hashbrown 0.16.1",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "indicatif"
+version = "0.17.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235"
+dependencies = [
+ "console",
+ "number_prefix",
+ "portable-atomic",
+ "unicode-width 0.2.2",
+ "web-time",
 ]
 
 [[package]]
@@ -1203,7 +1494,7 @@ dependencies = [
  "dyn-clone",
  "fuzzy-matcher",
  "unicode-segmentation",
- "unicode-width",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -1214,9 +1505,9 @@ checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "iri-string"
-version = "0.7.10"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
+checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
 dependencies = [
  "memchr",
  "serde",
@@ -1235,6 +1526,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "jni"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+dependencies = [
+ "cesu8",
+ "cfg-if",
+ "combine",
+ "jni-sys 0.3.1",
+ "log",
+ "thiserror 1.0.69",
+ "walkdir",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
+dependencies = [
+ "jni-sys 0.4.1",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "jobserver"
 version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1246,10 +1581,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.91"
+version = "0.3.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
+checksum = "2e04e2ef80ce82e13552136fabeef8a5ed1f985a96805761cbb9a2c34e7664d9"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -1266,6 +1603,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy-regex"
+version = "3.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bae91019476d3ec7147de9aa291cadb6d870abf2f3015d2da73a90325ac1496"
+dependencies = [
+ "lazy-regex-proc_macros",
+ "once_cell",
+ "regex",
+]
+
+[[package]]
+name = "lazy-regex-proc_macros"
+version = "3.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4de9c1e1439d8b7b3061b2d209809f447ca33241733d9a3c01eabf2dc8d94358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "regex",
+ "syn",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1279,9 +1639,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.183"
+version = "0.2.184"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1291,9 +1651,9 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "litrs"
@@ -1369,6 +1729,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
+
+[[package]]
+name = "minimad"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9c5d708226d186590a7b6d4a9780e2bdda5f689e0d58cd17012a298efd745d2"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1380,14 +1765,33 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "log",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "nanoid"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ffa00dec017b5b1a8b7cf5e2c008bfda1aa7e0697ac1508b491fdf2622fb4d8"
+dependencies = [
+ "rand 0.8.5",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -1401,9 +1805,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
 
 [[package]]
 name = "num-traits"
@@ -1413,6 +1817,12 @@ checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
 ]
+
+[[package]]
+name = "number_prefix"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "oauth2"
@@ -1450,6 +1860,21 @@ name = "opaque-debug"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "ordered-float"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7d950ca161dc355eaf28f82b11345ed76c6e1f6eb1f4f4479e0323b9e2fbd0e"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "ordered-multimap"
@@ -1568,9 +1993,12 @@ dependencies = [
  "chrono",
  "clap",
  "config",
+ "console",
+ "dialoguer",
  "flate2",
  "hmac",
  "home",
+ "indicatif",
  "inquire",
  "log",
  "lz4",
@@ -1578,6 +2006,7 @@ dependencies = [
  "pbkdf2",
  "rand 0.9.2",
  "reqwest 0.12.28",
+ "rig-core",
  "rmcp",
  "rpassword",
  "scram-2",
@@ -1587,6 +2016,7 @@ dependencies = [
  "sha2",
  "syslog-tracing",
  "tempfile",
+ "termimad",
  "tokio",
  "tracing",
  "tracing-appender",
@@ -1598,16 +2028,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "pin-project"
+version = "1.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
-
-[[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
@@ -1628,10 +2072,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "potential_utf"
-version = "0.1.4"
+name = "portable-atomic"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "potential_utf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
@@ -1696,6 +2146,7 @@ version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
+ "aws-lc-rs",
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
@@ -1852,6 +2303,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "regex-automata"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1903,7 +2366,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]
@@ -1914,21 +2377,31 @@ checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
 dependencies = [
  "base64",
  "bytes",
+ "encoding_rs",
  "futures-core",
  "futures-util",
+ "h2",
  "http",
  "http-body",
  "http-body-util",
  "hyper",
+ "hyper-rustls",
  "hyper-util",
  "js-sys",
  "log",
+ "mime",
+ "mime_guess",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
  "serde",
  "serde_json",
  "sync_wrapper",
  "tokio",
+ "tokio-rustls",
  "tokio-util",
  "tower",
  "tower-http",
@@ -1945,6 +2418,39 @@ name = "result"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "194d8e591e405d1eecf28819740abed6d719d1a2db87fc0bcdedee9a26d55560"
+
+[[package]]
+name = "rig-core"
+version = "0.34.0"
+source = "git+https://github.com/0xPlaygrounds/rig.git#54bbf79430103916a84d224b06dfa7990a049eaf"
+dependencies = [
+ "as-any",
+ "async-stream",
+ "base64",
+ "bytes",
+ "eventsource-stream",
+ "fastrand",
+ "futures",
+ "futures-timer",
+ "glob",
+ "http",
+ "mime",
+ "mime_guess",
+ "nanoid",
+ "ordered-float",
+ "pin-project-lite",
+ "reqwest 0.13.2",
+ "rmcp",
+ "schemars",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-tungstenite",
+ "tracing",
+ "tracing-futures",
+ "url",
+]
 
 [[package]]
 name = "ring"
@@ -2009,9 +2515,9 @@ dependencies = [
 
 [[package]]
 name = "ron"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd490c5b18261893f14449cbd28cb9c0b637aebf161cd77900bfdedaff21ec32"
+checksum = "4147b952f3f819eca0e99527022f7d6a8d05f111aeb0a62960c74eb283bec8fc"
 dependencies = [
  "bitflags",
  "once_cell",
@@ -2054,9 +2560,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustc_version"
@@ -2086,12 +2592,25 @@ version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
+ "aws-lc-rs",
  "once_cell",
  "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
 ]
 
 [[package]]
@@ -2105,11 +2624,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-platform-verifier"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
+dependencies = [
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
 name = "rustls-webpki"
 version = "0.103.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -2126,6 +2673,24 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "schemars"
@@ -2171,10 +2736,33 @@ dependencies = [
 ]
 
 [[package]]
-name = "semver"
-version = "1.0.27"
+name = "security-framework"
+version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags",
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -2266,9 +2854,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "1.0.4"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
 ]
@@ -2283,6 +2871,17 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest",
 ]
 
 [[package]]
@@ -2304,6 +2903,12 @@ checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
 ]
+
+[[package]]
+name = "shell-words"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
 
 [[package]]
 name = "shlex"
@@ -2344,9 +2949,9 @@ dependencies = [
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "slab"
@@ -2388,6 +2993,12 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "strict"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f42444fea5b87a39db4218d9422087e66a85d0e7a0963a439b07bcdf91804006"
 
 [[package]]
 name = "strsim"
@@ -2444,6 +3055,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "system-configuration"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
+dependencies = [
+ "bitflags",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2454,6 +3086,22 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "termimad"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22117210909e9dfff30a558f554c7fb3edb198ef614e7691386785fb7679677c"
+dependencies = [
+ "coolor",
+ "crokey",
+ "crossbeam",
+ "lazy-regex",
+ "minimad",
+ "serde",
+ "thiserror 1.0.69",
+ "unicode-width 0.1.14",
 ]
 
 [[package]]
@@ -2547,9 +3195,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -2572,9 +3220,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.50.0"
+version = "1.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+checksum = "2bd1c4c0fc4a7ab90fc15ef6daaa3ec3b893f004f915f2392557ed23237820cd"
 dependencies = [
  "bytes",
  "libc",
@@ -2589,9 +3237,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.1"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2620,6 +3268,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tungstenite"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6989540ced10490aaf14e6bad2e3d33728a2813310a0c71d1574304c49631cd"
+dependencies = [
+ "futures-util",
+ "log",
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tungstenite",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2634,9 +3298,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "1.0.7+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd28d57d8a6f6e458bc0b8784f8fdcc4b99a437936056fa122cb234f18656a96"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
  "indexmap",
  "serde_core",
@@ -2649,27 +3313,27 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "1.0.1+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b320e741db58cac564e26c607d3cc1fdc4a88fd36c879568c07856ed83ff3e9"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
  "serde_core",
 ]
 
 [[package]]
 name = "toml_parser"
-version = "1.0.10+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7df25b4befd31c4816df190124375d5a20c6b6921e2cad937316de3fccd63420"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
  "winnow",
 ]
 
 [[package]]
 name = "toml_writer"
-version = "1.0.7+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f17aaa1c6e3dc22b1da4b6bba97d066e354c7945cac2f7852d4e4e7ca7a6b56d"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tower"
@@ -2763,6 +3427,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-futures"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
+dependencies = [
+ "futures",
+ "futures-task",
+ "pin-project",
+ "tracing",
+]
+
+[[package]]
 name = "tracing-log"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2809,6 +3485,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "tungstenite"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e2ce1e47ed2994fd43b04c8f618008d4cabdd5ee34027cf14f9d918edd9c8"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.8.5",
+ "rustls",
+ "rustls-pki-types",
+ "sha1",
+ "thiserror 1.0.69",
+ "utf-8",
+]
+
+[[package]]
 name = "typeid"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2827,6 +3523,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2834,9 +3536,15 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.12.0"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-width"
@@ -2880,6 +3588,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
 name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2893,9 +3607,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.22.0"
+version = "1.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a68d3c8f01c0cfa54a75291d83601161799e4a89a39e0929f4b0354d88757a37"
+checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
@@ -2919,6 +3633,16 @@ name = "void"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
 
 [[package]]
 name = "want"
@@ -2955,9 +3679,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.114"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
+checksum = "0551fc1bb415591e3372d0bc4780db7e587d84e2a7e79da121051c5c4b89d0b0"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -2968,23 +3692,19 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.64"
+version = "0.4.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
+checksum = "03623de6905b7206edd0a75f69f747f134b7f0a2323392d664448bf2d3c5d87e"
 dependencies = [
- "cfg-if",
- "futures-util",
  "js-sys",
- "once_cell",
  "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.114"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
+checksum = "7fbdf9a35adf44786aecd5ff89b4563a90325f9da0923236f6104e603c7e86be"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2992,9 +3712,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.114"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
+checksum = "dca9693ef2bab6d4e6707234500350d8dad079eb508dca05530c85dc3a529ff2"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -3005,9 +3725,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.114"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
+checksum = "39129a682a6d2d841b6c429d0c51e5cb0ed1a03829d8b3d1e69a011e62cb3d3b"
 dependencies = [
  "unicode-ident",
 ]
@@ -3061,9 +3781,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.91"
+version = "0.3.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
+checksum = "cd70027e39b12f0849461e08ffc50b9cd7688d942c1c8e3c7b22273236b4dd0a"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3077,6 +3797,24 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]
@@ -3109,6 +3847,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"
@@ -3158,6 +3905,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+dependencies = [
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
 name = "windows-result"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3173,6 +3931,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
 ]
 
 [[package]]
@@ -3213,6 +3980,21 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-targets"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
@@ -3246,6 +4028,12 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -3258,6 +4046,12 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -3267,6 +4061,12 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3294,6 +4094,12 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -3303,6 +4109,12 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -3318,6 +4130,12 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -3327,6 +4145,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -3356,9 +4180,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a90e88e4667264a994d34e6d1ab2d26d398dcdca8b7f52bec8668957517fc7d8"
+checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
 dependencies = [
  "memchr",
 ]
@@ -3473,9 +4297,9 @@ dependencies = [
 
 [[package]]
 name = "writeable"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "yaml-rust2"
@@ -3490,9 +4314,9 @@ dependencies = [
 
 [[package]]
 name = "yoke"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -3501,9 +4325,9 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3513,18 +4337,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.47"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efbb2a062be311f2ba113ce66f697a4dc589f85e78a4aea276200804cea0ed87"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.47"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e8bc7269b54418e7aeeef514aa68f8690b8c0489a06b0136e5f57c4c5ccab89"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3533,18 +4357,18 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3560,9 +4384,9 @@ checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zerotrie"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -3571,9 +4395,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -3582,9 +4406,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,15 @@ path = "src/bin/admin/admin.rs"
 name = "pgmoneta-mcp-inspector"
 path = "src/bin/inspector/main.rs"
 
+[[bin]]
+name = "pgmoneta-mcp-client"
+path = "src/bin/client/main.rs"
+
 [dependencies]
+dialoguer = "0.11"
+indicatif = "0.17"
+console = "0.15"
+termimad = "0.30"
 tokio = {version = "1", features = ["full"] }
 serde = { version = "1", features = ["derive"] }
 rmcp = { version = "1.3", features = [
@@ -67,6 +75,7 @@ syslog-tracing = "0.3.1"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 inquire = "0.9.4"
 treelog = { version = "0.0.6", features = ["arbitrary-json"] }
+rig = { git = "https://github.com/0xPlaygrounds/rig.git", package = "rig-core", features = ["rmcp"] }
 [target.'cfg(windows)'.dependencies]
 winlog2 = "0.3.2"
 log = "0.4"

--- a/doc/manual/en/24-vllm.md
+++ b/doc/manual/en/24-vllm.md
@@ -36,7 +36,16 @@ export HF_HOME=/mnt/ai/huggingface
 
 ### Start the server
 
-Start the vLLM server by pointing the `openai.api_server` entrypoint to your desired model. vLLM will automatically download the model weights to the Hugging Face cache if they are not already present.
+Start the vLLM server with tool-calling support enabled. The `--enable-auto-tool-choice` and `--tool-call-parser` flags are **required** for pgmoneta_mcp to invoke MCP tools.
+
+```sh
+vllm serve ibm-granite/granite-3.0-8b-instruct \
+  --port 8000 \
+  --enable-auto-tool-choice \
+  --tool-call-parser granite
+```
+
+Or using the Python module entrypoint:
 
 **Small setup** (Laptop friendly, ~8GB RAM req):
 ```sh
@@ -49,7 +58,9 @@ HF_HOME=/mnt/ai/huggingface python -m vllm.entrypoints.openai.api_server \
 ```sh
 HF_HOME=/mnt/ai/huggingface python -m vllm.entrypoints.openai.api_server \
   --model ibm-granite/granite-3.0-8b-instruct \
-  --port 8000
+  --port 8000 \
+  --enable-auto-tool-choice \
+  --tool-call-parser granite
 ```
 
 **Full setup** (Workstation only):
@@ -57,8 +68,18 @@ HF_HOME=/mnt/ai/huggingface python -m vllm.entrypoints.openai.api_server \
 HF_HOME=/mnt/ai/huggingface python -m vllm.entrypoints.openai.api_server \
   --model meta-llama/Meta-Llama-3.1-70B-Instruct \
   --port 8000 \
-  --tensor-parallel-size 4
+  --tensor-parallel-size 4 \
+  --enable-auto-tool-choice \
+  --tool-call-parser llama3_json
 ```
+
+The `--tool-call-parser` value depends on the model ([vLLM docs](https://docs.vllm.ai/en/latest/features/tool_calling.html)):
+
+| Model | Parser |
+| :---- | :----- |
+| ibm-granite/granite-3.0-8b-instruct | `granite` |
+| Qwen/Qwen2.5-\*-Instruct | `hermes` |
+| meta-llama/Llama-3.1-\*-Instruct | `llama3_json` |
 
 The default endpoint will be `http://localhost:8000`.
 

--- a/doc/manual/en/40-chat-client.md
+++ b/doc/manual/en/40-chat-client.md
@@ -1,0 +1,65 @@
+## Chat Client
+
+The chat client provides an interactive conversational interface to manage PostgreSQL backups using natural language.
+
+### Configuration
+
+The chat client requires both `[pgmoneta_mcp]` and `[llm]` sections in your `pgmoneta-mcp.conf`.
+
+#### pgmoneta_mcp
+
+| Parameter | Required | Default | Description |
+| :--- | :--- | :--- | :--- |
+| port | Yes | - | MCP server port |
+
+#### llm
+
+| Parameter | Required | Default | Description |
+| :--- | :--- | :--- | :--- |
+| provider | Yes | - | LLM backend: `ollama`, `llama.cpp`, `ramalama`, `vllm` |
+| endpoint | Yes | - | LLM server URL |
+| model | No | Provider default | Model name |
+| max_tool_rounds | No | 10 | Max tool-calling rounds |
+| temperature | No | - | Sampling temperature (0.0-2.0) |
+| max_tokens | No | - | Token limit |
+
+Example:
+
+``` ini
+[pgmoneta_mcp]
+port = 8000
+
+[pgmoneta]
+
+[admins]
+
+[llm]
+provider = ollama
+endpoint = http://localhost:11434
+model = llama3.1
+```
+
+### Usage
+
+``` sh
+./pgmoneta-mcp-client -c /etc/pgmoneta-mcp/pgmoneta-mcp.conf
+```
+
+### Commands
+
+| Command | Description |
+| :--- | :--- |
+| /help | Show available commands |
+| /clear | Clear conversation history |
+| /model \<name\> | Switch LLM model |
+| /provider \<name\> | Switch provider |
+| /endpoint \<url\> | Change server endpoint |
+| /temperature \<n\> | Set temperature |
+| /max-tokens \<n\> | Set token limit |
+| /config | Show current configuration |
+| /exit | Exit chat |
+| /quit | Exit chat |
+
+### Keyboard Shortcuts
+
+- **Ctrl+C** - Cancel current request

--- a/src/bin/client/main.rs
+++ b/src/bin/client/main.rs
@@ -1,0 +1,153 @@
+// Copyright (C) 2026 The pgmoneta community
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+use anyhow::{Result, anyhow};
+use clap::Parser;
+use console::style;
+use dialoguer::Input;
+use pgmoneta_mcp::chat_client::{self, commands};
+use pgmoneta_mcp::configuration;
+
+/// FIGlet ASCII art banner for pgmoneta (ANSI Shadow font from patorjk.com)
+const LOGO: &str = r#"
+██████╗  ██████╗ ███╗   ███╗ ██████╗ ███╗   ██╗███████╗████████╗ █████╗
+██╔══██╗██╔════╝ ████╗ ████║██╔═══██╗████╗  ██║██╔════╝╚══██╔══╝██╔══██╗
+██████╔╝██║  ███╗██╔████╔██║██║   ██║██╔██╗ ██║█████╗     ██║   ███████║
+██╔═══╝ ██║   ██║██║╚██╔╝██║██║   ██║██║╚██╗██║██╔══╝     ██║   ██╔══██║
+██║     ╚██████╔╝██║ ╚═╝ ██║╚██████╔╝██║ ╚████║███████╗   ██║   ██║  ██║
+╚═╝      ╚═════╝ ╚═╝     ╚═╝ ╚═════╝ ╚═╝  ╚═══╝╚══════╝   ╚═╝   ╚═╝  ╚═╝
+"#;
+
+#[derive(Parser, Debug)]
+#[command(
+    name = "pgmoneta-mcp-client",
+    about = "Interactive LLM chat client for pgmoneta-mcp"
+)]
+struct Args {
+    /// Path to main configuration file
+    #[arg(
+        short = 'c',
+        long,
+        default_value = "/etc/pgmoneta-mcp/pgmoneta-mcp.conf"
+    )]
+    config: String,
+}
+
+fn print_banner(provider: &str, model: &str, endpoint: &str) {
+    eprintln!();
+    // Print FIGlet logo in orange (closest ANSI: yellow/208)
+    for line in LOGO.lines() {
+        if !line.is_empty() {
+            eprintln!("{}", style(line).color256(208).bold());
+        }
+    }
+
+    // Info line
+    eprintln!(
+        "  {} {} · {} {} · {} {}",
+        style("Model:").dim(),
+        style(model).cyan().bold(),
+        style("Provider:").dim(),
+        style(provider).cyan().bold(),
+        style("Endpoint:").dim(),
+        style(endpoint).cyan(),
+    );
+    eprintln!();
+    eprintln!(
+        "  {} · {} · {}",
+        style("Ctrl+C cancel").dim(),
+        style("/help commands").dim(),
+        style("/quit exit").dim(),
+    );
+    eprintln!();
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let args = Args::parse();
+
+    // Load configurations
+    let config = configuration::load_base_configuration(&args.config)?;
+    let mcp_config = config.pgmoneta_mcp.clone();
+    let mut llm_config = config
+        .llm
+        .clone()
+        .ok_or_else(|| anyhow!("No [llm] section in configuration file"))?;
+
+    // Build agent with MCP Tools
+    let mut chat_agent = chat_client::build_agent(&llm_config, &mcp_config).await?;
+
+    // Print banner
+    print_banner(
+        &llm_config.provider,
+        &llm_config.model,
+        &llm_config.endpoint,
+    );
+
+    loop {
+        // Styled prompt: you@provider>
+        let prompt_text = format!(
+            "{}@{}",
+            style("you").green().bold(),
+            style(&llm_config.provider).cyan()
+        );
+
+        let input: String = match Input::new()
+            .with_prompt(&prompt_text)
+            .allow_empty(true)
+            .interact_text()
+        {
+            Ok(input) => input,
+            Err(_) => {
+                eprintln!("\n{}", style("Goodbye! 👋").dim());
+                break;
+            }
+        };
+
+        let input = input.trim();
+        if input.is_empty() {
+            continue;
+        }
+
+        if input == "/exit" || input == "/quit" {
+            eprintln!("{}", style("Goodbye! 👋").dim());
+            break;
+        }
+
+        // Slash command → delegate entirely to commands module
+        if input.starts_with('/') {
+            commands::handle(input, &mut chat_agent, &mut llm_config, &mcp_config).await;
+            continue;
+        }
+
+        // Send to agent and render the response with markdown
+        match chat_agent.prompt(input).await {
+            Ok(output) => {
+                eprintln!();
+                // Render LLM response as terminal markdown
+                termimad::print_text(&output);
+                eprintln!();
+            }
+            Err(e) => {
+                // If the error was just "Cancelled", don't spam stack traces
+                if e.to_string() != "Cancelled" {
+                    eprintln!("\n  {} {}\n", style("Error:").red().bold(), style(e).red());
+                }
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/src/chat_client/chat_hook.rs
+++ b/src/chat_client/chat_hook.rs
@@ -1,0 +1,272 @@
+// Copyright (C) 2026 The pgmoneta community
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+use console::style;
+use indicatif::{ProgressBar, ProgressStyle};
+use rig::agent::{HookAction, PromptHook, ToolCallHookAction};
+use rig::completion::{CompletionModel, CompletionResponse, Message};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+use tokio::sync::Mutex;
+
+/// PromptHook implementation providing a professional chain-style UI
+/// with animated spinners, streaming output, and rich tool call display.
+#[derive(Clone)]
+pub struct ChatHook {
+    state: Arc<Mutex<ChainState>>,
+}
+
+struct ChainState {
+    provider_label: String,
+    round: usize,
+    tool_start: Option<Instant>,
+    input_tokens: u64,
+    output_tokens: u64,
+    tool_count: usize,
+    last_error: Option<String>,
+    prompt_start: Instant,
+    spinner: Option<ProgressBar>,
+}
+
+impl ChainState {
+    fn start_spinner(&mut self, msg: &str) {
+        // Finish any existing spinner first
+        self.finish_spinner();
+        let pb = ProgressBar::new_spinner();
+        pb.set_style(
+            ProgressStyle::with_template("  {spinner:.cyan} {msg}")
+                .unwrap()
+                .tick_strings(&["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏", "✔"]),
+        );
+        pb.set_message(msg.to_string());
+        pb.enable_steady_tick(Duration::from_millis(80));
+        self.spinner = Some(pb);
+    }
+
+    fn finish_spinner(&mut self) {
+        if let Some(pb) = self.spinner.take() {
+            pb.finish_and_clear();
+        }
+    }
+}
+
+impl ChatHook {
+    pub fn new(provider: &str, model: &str, endpoint: &str) -> Self {
+        let label = format!("{model} ({provider} @ {endpoint})");
+        Self {
+            state: Arc::new(Mutex::new(ChainState {
+                provider_label: label,
+                round: 0,
+                tool_start: None,
+                input_tokens: 0,
+                output_tokens: 0,
+                tool_count: 0,
+                last_error: None,
+                prompt_start: Instant::now(),
+                spinner: None,
+            })),
+        }
+    }
+
+    pub fn reset(&self) {
+        if let Ok(mut state) = self.state.try_lock() {
+            state.finish_spinner();
+            state.round = 0;
+            state.input_tokens = 0;
+            state.output_tokens = 0;
+            state.tool_count = 0;
+            state.tool_start = None;
+            state.last_error = None;
+            state.prompt_start = Instant::now();
+        }
+    }
+
+    pub async fn clear_chain(&self) {
+        let mut state = self.state.lock().await;
+        state.finish_spinner();
+    }
+
+    pub async fn print_final_summary(&self) {
+        let mut state = self.state.lock().await;
+        state.finish_spinner();
+
+        let elapsed = state.prompt_start.elapsed().as_secs_f32();
+        let tools = state.tool_count;
+        let t_in = state.input_tokens;
+        let t_out = state.output_tokens;
+
+        let mut parts: Vec<String> = Vec::new();
+        if tools > 0 {
+            parts.push(format!(
+                "{} tool{}",
+                tools,
+                if tools > 1 { "s" } else { "" }
+            ));
+        }
+        parts.push(format!("{}→{} tokens", t_in, t_out));
+        parts.push(format!("{elapsed:.1}s"));
+
+        eprintln!(
+            "  {} {}",
+            style("✔").green().bold(),
+            style(format!("Done ({})", parts.join(" · "))).dim()
+        );
+
+        if let Some(err) = &state.last_error {
+            eprintln!("  {} {}", style("⚠").yellow(), style(err).dim());
+        }
+    }
+
+    pub async fn print_error_summary(&self, error: &str) {
+        let mut state = self.state.lock().await;
+        state.finish_spinner();
+        let elapsed = state.prompt_start.elapsed().as_secs_f32();
+        eprintln!(
+            "  {} {} · {elapsed:.1}s",
+            style("✖").red().bold(),
+            style(error).red()
+        );
+    }
+
+    fn format_args_inline(args: &str) -> String {
+        if let Ok(serde_json::Value::Object(obj)) = serde_json::from_str::<serde_json::Value>(args)
+        {
+            let formatted: Vec<String> = obj
+                .iter()
+                .map(|(k, v)| {
+                    let val_str = match v {
+                        serde_json::Value::String(s) => {
+                            if s.len() > 30 {
+                                format!("\"{}...\"", &s[..27])
+                            } else {
+                                format!("\"{s}\"")
+                            }
+                        }
+                        other => {
+                            let s = other.to_string();
+                            if s.len() > 30 {
+                                format!("{}...", &s[..27])
+                            } else {
+                                s
+                            }
+                        }
+                    };
+                    format!("{k}={val_str}")
+                })
+                .collect();
+            return formatted.join(", ");
+        }
+        String::new()
+    }
+}
+
+impl<M: CompletionModel> PromptHook<M> for ChatHook {
+    async fn on_completion_call(&self, _prompt: &Message, _history: &[Message]) -> HookAction {
+        let mut state = self.state.lock().await;
+        state.round += 1;
+        let r = state.round;
+
+        let label = state.provider_label.clone();
+        if r == 1 {
+            state.start_spinner(&format!(
+                "Thinking... {}",
+                style(format!("({label})")).dim()
+            ));
+        } else {
+            state.start_spinner(&format!(
+                "Processing results... {}",
+                style(format!("(round {r})")).dim()
+            ));
+        }
+        HookAction::cont()
+    }
+
+    async fn on_completion_response(
+        &self,
+        _prompt: &Message,
+        response: &CompletionResponse<M::Response>,
+    ) -> HookAction {
+        let mut state = self.state.lock().await;
+        state.input_tokens = response.usage.input_tokens;
+        state.output_tokens = response.usage.output_tokens;
+        state.finish_spinner();
+        HookAction::cont()
+    }
+
+    async fn on_tool_call(
+        &self,
+        tool_name: &str,
+        _tool_call_id: Option<String>,
+        _internal_call_id: &str,
+        args: &str,
+    ) -> ToolCallHookAction {
+        let mut state = self.state.lock().await;
+        state.tool_count += 1;
+        state.tool_start = Some(Instant::now());
+
+        let args_preview = Self::format_args_inline(args);
+        let tool_display = if args_preview.is_empty() {
+            tool_name.to_string()
+        } else {
+            format!("{tool_name}({args_preview})")
+        };
+
+        state.start_spinner(&format!("Calling {}...", style(&tool_display).cyan()));
+        ToolCallHookAction::cont()
+    }
+
+    async fn on_tool_result(
+        &self,
+        tool_name: &str,
+        _tool_call_id: Option<String>,
+        _internal_call_id: &str,
+        _args: &str,
+        result: &str,
+    ) -> HookAction {
+        let mut state = self.state.lock().await;
+        let ms = state
+            .tool_start
+            .map(|t| t.elapsed().as_millis())
+            .unwrap_or(0);
+
+        state.finish_spinner();
+
+        let is_error =
+            result.to_lowercase().contains("error") || result.to_lowercase().contains("failed");
+
+        if is_error {
+            let preview = if result.len() > 60 {
+                format!("{}...", &result[..60])
+            } else {
+                result.to_string()
+            };
+            state.last_error = Some(format!("{tool_name}: {preview}"));
+            eprintln!(
+                "  {} {} {}",
+                style("✖").red(),
+                style(tool_name).red(),
+                style(format!("{ms}ms")).dim()
+            );
+        } else {
+            eprintln!(
+                "  {} {} {}",
+                style("✔").green(),
+                style(tool_name).cyan(),
+                style(format!("{ms}ms")).dim()
+            );
+        }
+        HookAction::cont()
+    }
+}

--- a/src/chat_client/commands.rs
+++ b/src/chat_client/commands.rs
@@ -1,0 +1,233 @@
+// Copyright (C) 2026 The pgmoneta community
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+use crate::chat_client::{self, Agent};
+use crate::configuration::{LlmConfiguration, PgmonetaMcpConfiguration};
+use console::style;
+
+// ── Helper display functions ──────────────────────────────────────
+
+fn print_section(title: &str) {
+    eprintln!();
+    eprintln!("  {}", style(title).bold().underlined());
+    eprintln!();
+}
+
+fn print_help_row(cmd: &str, desc: &str) {
+    eprintln!("    {}  {}", style(cmd).cyan().bold(), style(desc).dim());
+}
+
+fn print_config_row(key: &str, value: &str) {
+    eprintln!("    {} {}", style(key).dim(), style(value).cyan().bold());
+}
+
+fn print_success(msg: &str) {
+    eprintln!("  {} {}", style("✔").green(), msg);
+}
+
+fn print_error(msg: &str) {
+    eprintln!("  {} {}", style("✖").red(), msg);
+}
+
+// ── Slash command handler ─────────────────────────────────────────
+
+/// Process a slash command. Called only when input starts with '/'.
+pub async fn handle(
+    input: &str,
+    agent: &mut Agent,
+    config: &mut LlmConfiguration,
+    mcp_config: &PgmonetaMcpConfiguration,
+) {
+    let parts: Vec<&str> = input.splitn(2, ' ').collect();
+    let cmd = parts[0];
+    let arg = parts.get(1).map(|s| s.trim()).unwrap_or("");
+
+    match cmd {
+        "/help" => {
+            print_section("Available Commands");
+            print_help_row("/clear", "Clear conversation history");
+            print_help_row("/model <name>", "Switch the LLM model");
+            print_help_row(
+                "/provider <name>",
+                "Switch provider (ollama/llama.cpp/ramalama/vllm)",
+            );
+            print_help_row("/endpoint <url>", "Change backend endpoint");
+            print_help_row("/temperature <n>", "Set temperature (0.0 - 2.0)");
+            print_help_row("/max-tokens <n>", "Set token limit");
+            print_help_row("/config", "Show current configuration");
+            print_help_row("/exit, /quit", "Exit the chat");
+        }
+
+        "/config" => {
+            print_section("Current Configuration");
+            print_config_row("Provider:", &config.provider);
+            print_config_row("Model:", &config.model);
+            print_config_row("Endpoint:", &config.endpoint);
+            print_config_row(
+                "Temperature:",
+                &config
+                    .temperature
+                    .map_or("default".into(), |t| t.to_string()),
+            );
+            print_config_row(
+                "Max tokens:",
+                &config
+                    .max_tokens
+                    .map_or("default".into(), |t| t.to_string()),
+            );
+            print_config_row("Max rounds:", &config.max_tool_rounds.to_string());
+        }
+
+        "/clear" => {
+            agent.clear_history();
+            print_success(&format!("{}", style("History cleared").dim()));
+        }
+
+        "/model" => {
+            if arg.is_empty() {
+                print_config_row("Current model:", &config.model);
+                eprintln!("  {} /model <name>", style("Usage:").dim());
+            } else {
+                rebuild_with(
+                    agent,
+                    config,
+                    mcp_config,
+                    |c| c.model = arg.to_string(),
+                    &format!("Model changed to {}", style(arg).cyan().bold()),
+                )
+                .await;
+            }
+        }
+
+        "/provider" => {
+            if arg.is_empty() {
+                print_config_row("Current provider:", &config.provider);
+                eprintln!(
+                    "  {} /provider <ollama|llama.cpp|ramalama|vllm>",
+                    style("Usage:").dim()
+                );
+            } else {
+                rebuild_with(
+                    agent,
+                    config,
+                    mcp_config,
+                    |c| {
+                        c.provider = arg.to_string();
+                        c.model = String::new();
+                    },
+                    &format!("Provider changed to {}", style(arg).cyan().bold()),
+                )
+                .await;
+            }
+        }
+
+        "/endpoint" => {
+            if arg.is_empty() {
+                print_config_row("Current endpoint:", &config.endpoint);
+                eprintln!("  {} /endpoint <url>", style("Usage:").dim());
+            } else {
+                rebuild_with(
+                    agent,
+                    config,
+                    mcp_config,
+                    |c| c.endpoint = arg.to_string(),
+                    &format!("Endpoint changed to {}", style(arg).cyan()),
+                )
+                .await;
+            }
+        }
+
+        "/temperature" => {
+            if arg.is_empty() {
+                print_config_row(
+                    "Current temperature:",
+                    &config
+                        .temperature
+                        .map_or("default".into(), |t| t.to_string()),
+                );
+                eprintln!("  {} /temperature <0.0-2.0>", style("Usage:").dim());
+            } else {
+                match arg.parse::<f64>() {
+                    Ok(t) => {
+                        rebuild_with(
+                            agent,
+                            config,
+                            mcp_config,
+                            |c| c.temperature = Some(t),
+                            &format!("Temperature set to {}", style(t).bold()),
+                        )
+                        .await
+                    }
+                    Err(_) => print_error("Invalid temperature"),
+                }
+            }
+        }
+
+        "/max-tokens" => {
+            if arg.is_empty() {
+                print_config_row(
+                    "Current max tokens:",
+                    &config
+                        .max_tokens
+                        .map_or("default".into(), |t| t.to_string()),
+                );
+                eprintln!("  {} /max-tokens <num>", style("Usage:").dim());
+            } else {
+                match arg.parse::<u64>() {
+                    Ok(m) => {
+                        rebuild_with(
+                            agent,
+                            config,
+                            mcp_config,
+                            |c| c.max_tokens = Some(m),
+                            &format!("Max tokens set to {}", style(m).bold()),
+                        )
+                        .await
+                    }
+                    Err(_) => print_error("Invalid token limit"),
+                }
+            }
+        }
+
+        _ => eprintln!(
+            "  {} Unknown command: {}. Type {} for available commands.",
+            style("✖").red(),
+            style(cmd).yellow(),
+            style("/help").cyan().bold()
+        ),
+    }
+
+    eprintln!();
+}
+
+/// Apply a config mutation, rebuild the agent, and update both in place.
+async fn rebuild_with(
+    agent: &mut Agent,
+    config: &mut LlmConfiguration,
+    mcp_config: &PgmonetaMcpConfiguration,
+    mutate: impl FnOnce(&mut LlmConfiguration),
+    success_msg: &str,
+) {
+    let mut new_config = config.clone();
+    mutate(&mut new_config);
+    match chat_client::build_agent(&new_config, mcp_config).await {
+        Ok(new_agent) => {
+            *agent = new_agent;
+            *config = new_config;
+            print_success(success_msg);
+        }
+        Err(e) => print_error(&format!("Failed: {e}")),
+    }
+}

--- a/src/chat_client/mod.rs
+++ b/src/chat_client/mod.rs
@@ -1,0 +1,208 @@
+// Copyright (C) 2026 The pgmoneta community
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+pub mod chat_hook;
+pub mod commands;
+
+use crate::chat_client::chat_hook::ChatHook;
+use crate::configuration::{LlmConfiguration, PgmonetaMcpConfiguration};
+use anyhow::anyhow;
+use rig::agent::Agent as RigAgent;
+use rig::client::CompletionClient;
+use rig::client::Nothing;
+use rig::completion::{Message, Prompt};
+use rig::providers::{llamafile, ollama, openai};
+use rig::tool::rmcp::McpClientHandler;
+use rig::tool::server::ToolServer;
+use rmcp::model::{ClientCapabilities, ClientInfo, Implementation};
+use rmcp::service::{RoleClient, RunningService};
+
+/// Default system prompt for the pgmoneta backup management assistant.
+pub const SYSTEM_PROMPT: &str = "\
+You are a PostgreSQL backup management assistant powered by pgmoneta. \
+Help users with questions about backups, server status, and management operations. \
+When presenting information, format it in a clear, human-readable way.";
+
+/// Wraps different rig `Agent` types for runtime provider selection.
+pub enum AnyAgent {
+    Ollama(RigAgent<ollama::CompletionModel, ChatHook>),
+    Llamafile(RigAgent<llamafile::CompletionModel, ChatHook>),
+    OpenAiCompat(RigAgent<openai::completion::CompletionModel, ChatHook>),
+}
+
+/// Top-level agent managing conversation history and provider dispatch.
+pub struct Agent {
+    inner: AnyAgent,
+    history: Vec<Message>,
+    hook: ChatHook,
+    _mcp_service: RunningService<RoleClient, McpClientHandler>,
+}
+
+impl Agent {
+    /// Send a user prompt. Rig handles the multi-turn tool loop internally,
+    /// and manages the history.
+    pub async fn prompt(&mut self, input: &str) -> anyhow::Result<String> {
+        // Reset hook state for new prompt
+        self.hook.reset();
+
+        let prompt_future = async {
+            match &self.inner {
+                AnyAgent::Ollama(a) => a.prompt(input).with_history(self.history.clone()).await,
+                AnyAgent::Llamafile(a) => a.prompt(input).with_history(self.history.clone()).await,
+                AnyAgent::OpenAiCompat(a) => {
+                    a.prompt(input).with_history(self.history.clone()).await
+                }
+            }
+        };
+
+        // Run the agent prompt concurrently with a Ctrl+C listener
+        let result: Result<String, anyhow::Error> = tokio::select! {
+            res = prompt_future => res.map_err(|e| anyhow!("{e}")),
+            _ = tokio::signal::ctrl_c() => {
+                self.hook.clear_chain().await;
+                Err(anyhow!("Cancelled"))
+            }
+        };
+
+        match result {
+            Ok(response) => {
+                self.history.push(Message::user(input));
+                self.history.push(Message::assistant(&response));
+                self.hook.print_final_summary().await;
+                Ok(response)
+            }
+            Err(e) => {
+                self.hook.print_error_summary(&e.to_string()).await;
+                Err(e)
+            }
+        }
+    }
+
+    /// Clear conversation history.
+    pub fn clear_history(&mut self) {
+        self.history.clear();
+    }
+}
+
+/// Build an Agent from configuration.
+pub async fn build_agent(
+    config: &LlmConfiguration,
+    mcp_config: &PgmonetaMcpConfiguration,
+) -> anyhow::Result<Agent> {
+    let hook = ChatHook::new(&config.provider, &config.model, &config.endpoint);
+
+    let mcp_url = format!("http://127.0.0.1:{}/mcp", mcp_config.port);
+
+    let client_info = ClientInfo::new(
+        ClientCapabilities::default(),
+        Implementation::new(env!("CARGO_PKG_NAME"), env!("CARGO_PKG_VERSION")),
+    );
+
+    let tool_server_handle = ToolServer::new().run();
+    let handler = McpClientHandler::new(client_info, tool_server_handle.clone());
+
+    let transport = rmcp::transport::StreamableHttpClientTransport::from_uri(&*mcp_url);
+    let mcp_service = handler
+        .connect(transport)
+        .await
+        .map_err(|e| anyhow!("Failed to connect to MCP server: {:?}", e))?;
+
+    // 2. Build the LLM provider
+    let inner = match config.provider.as_str() {
+        "ollama" => {
+            let client = ollama::Client::builder()
+                .api_key(Nothing)
+                .base_url(&config.endpoint)
+                .build()
+                .map_err(|e| anyhow!("Failed to create Ollama client: {e}"))?;
+
+            let mut builder = client
+                .agent(&config.model)
+                .preamble(SYSTEM_PROMPT)
+                .hook(hook.clone())
+                .tool_server_handle(tool_server_handle.clone())
+                .default_max_turns(config.max_tool_rounds);
+
+            if let Some(t) = config.temperature {
+                builder = builder.temperature(t);
+            }
+            if let Some(m) = config.max_tokens {
+                builder = builder.max_tokens(m);
+            }
+
+            AnyAgent::Ollama(builder.build())
+        }
+
+        "llama.cpp" => {
+            let client = llamafile::Client::from_url(&config.endpoint);
+
+            let mut builder = client
+                .agent(&config.model)
+                .preamble(SYSTEM_PROMPT)
+                .hook(hook.clone())
+                .tool_server_handle(tool_server_handle.clone())
+                .default_max_turns(config.max_tool_rounds);
+
+            if let Some(t) = config.temperature {
+                builder = builder.temperature(t);
+            }
+            if let Some(m) = config.max_tokens {
+                builder = builder.max_tokens(m);
+            }
+
+            AnyAgent::Llamafile(builder.build())
+        }
+
+        // Fallback for providers not supported by rig but that
+        // expose an OpenAI-compatible API.
+        // To add a new provider, append its name to the match pattern below.
+        "ramalama" | "vllm" => {
+            // openai::CompletionsClient appends "/chat/completions" to the base URL,
+            // so we need to ensure the base URL includes the "/v1" prefix.
+            let base_url = format!("{}/v1", config.endpoint.trim_end_matches('/'));
+
+            let client = openai::CompletionsClient::builder()
+                .api_key("no-key")
+                .base_url(&base_url)
+                .build()
+                .map_err(|e| anyhow!("Failed to create OpenAI-compatible client: {e}"))?;
+
+            let mut builder = client
+                .agent(&config.model)
+                .preamble(SYSTEM_PROMPT)
+                .hook(hook.clone())
+                .tool_server_handle(tool_server_handle.clone())
+                .default_max_turns(config.max_tool_rounds);
+
+            if let Some(t) = config.temperature {
+                builder = builder.temperature(t);
+            }
+            if let Some(m) = config.max_tokens {
+                builder = builder.max_tokens(m);
+            }
+
+            AnyAgent::OpenAiCompat(builder.build())
+        }
+
+        other => return Err(anyhow!("Unsupported LLM provider '{}'", other)),
+    };
+
+    Ok(Agent {
+        inner,
+        history: Vec::new(),
+        hook,
+        _mcp_service: mcp_service,
+    })
+}

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -123,6 +123,10 @@ pub struct LlmConfiguration {
     /// Maximum number of tool-calling rounds per user prompt. Default: `10`.
     #[serde(default = "default_llm_max_tool_rounds")]
     pub max_tool_rounds: usize,
+    #[serde(default)]
+    pub temperature: Option<f64>,
+    #[serde(default)]
+    pub max_tokens: Option<u64>,
 }
 
 /// Configuration properties for the inspector.
@@ -165,6 +169,22 @@ pub fn load_configuration(config_path: &str, user_path: &str) -> anyhow::Result<
             "Error parsing configuration at path {}, user {}: {:?}",
             config_path,
             user_path,
+            e
+        )
+    })?;
+    normalize_configuration(conf)
+}
+
+/// Loads only the base configuration (no user/admin file needed).
+/// Used by chat binary which doesn't need admin credentials.
+pub fn load_base_configuration(config_path: &str) -> anyhow::Result<Configuration> {
+    let conf = Config::builder()
+        .add_source(config::File::with_name(config_path).format(FileFormat::Ini))
+        .build()?;
+    let conf = conf.try_deserialize::<Configuration>().map_err(|e| {
+        anyhow!(
+            "Error parsing configuration at path {}: {:?}",
+            config_path,
             e
         )
     })?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,7 @@
 //! * **`utils`**: Provides shared helper functions.
 
 pub mod agent;
+pub mod chat_client;
 pub mod compression;
 pub mod configuration;
 pub mod constant;


### PR DESCRIPTION
@jesperpedersen @Jubilee101 Recently, I studied rig and how to integrate it. It is interesting, as it can indeed significantly simplify our work by removing the need to build a custom MCP client, now it already supports more than 20 providers. It also provides a hooks system that allows us to track events such as completion call, tool call, and more.

However, I have encountered some challenges, which will be mentioned as comments in the code.

Currently, implemented a CLI interactive chat that provides a smooth user experience and a clean user interface, with hooks helping achieve that, while also allowing users to change configuration directly within the chat.
it now supports providers such as Ollama, llama.cpp, and Ramalama, and we can easily add any provider supported by rig, for unsupported providers, rig also offers a solution. 

The demo

[![asciicast](https://asciinema.org/a/zceHtAo8xplrEz9o.svg?v=2)](https://asciinema.org/a/zceHtAo8xplrEz9o)

Work is still ongoing on the documentation and improving the chat interface if needed.
Closes #80 