### PR TITLE
Fix early return in _translate_result dropping sibling fields after Backups array

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -14,3 +14,4 @@ manascb1344 <zephop76593@gmail.com>
 Shikhar Soni <shikharish05@gmail.com>
 Sakshi Aggarwal <sakshiaggarwal2706@gmail.com>
 Sarthak Aneja <sarthakaneja260@gmail.com>
+Sahitya Chandra <sahityajb@gmail.com>

--- a/doc/manual/en/97-acknowledgement.md
+++ b/doc/manual/en/97-acknowledgement.md
@@ -19,6 +19,7 @@ Nihal Kumar <collabwithnihal@gmail.com>
 Shikhar Soni <shikharish05@gmail.com>
 Sakshi Aggarwal <sakshiaggarwal2706@gmail.com>
 Sarthak Aneja <sarthakaneja260@gmail.com>
+Sahitya Chandra <sahityajb@gmail.com>
 ```
 
 ## Committers

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -192,17 +192,14 @@ impl PgmonetaHandler {
                 }
             } else if object_arr_fields.contains(&key.as_str()) {
                 let mut trans_arr: Vec<Value> = Vec::new();
-                if value.as_array().is_none() {
-                    trans_res.insert(key.clone(), value.clone());
-                    continue;
-                }
-                let arr = value.as_array().unwrap();
-                for item in arr {
-                    if let Value::Object(object) = item {
-                        let trans_obj = Self::_translate_result(object)?;
-                        trans_arr.push(Value::Object(trans_obj));
-                    } else {
-                        trans_arr.push(item.clone())
+                if let Some(arr) = value.as_array() {
+                    for item in arr {
+                        if let Value::Object(object) = item {
+                            let trans_obj = Self::_translate_result(object)?;
+                            trans_arr.push(Value::Object(trans_obj));
+                        } else {
+                            trans_arr.push(item.clone())
+                        }
                     }
                 }
                 trans_res.insert(key.clone(), Value::from(trans_arr));


### PR DESCRIPTION
Fixes #96

## Summary

- Removed two early `return Ok(trans_res)` statements in the `object_arr_fields` branch of `_translate_result`
- Consolidated the array-or-not check into a single `if let Some(arr)` so the loop always continues after processing an array field
- Sibling fields like `MajorVersion`, `MinorVersion`, `NumberOfBackups`, `Server`, and `ServerVersion` are now correctly included in the translated response

## Test plan

- [ ] Call `list_backups` and verify the translated response includes `MajorVersion`, `MinorVersion`, `NumberOfBackups`, `Server`, and `ServerVersion`
- [x] Verify existing tests still pass (`cargo test`)