### PR TITLE
[#98]  Fix llama.cpp web UI connection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1755,6 +1755,7 @@ dependencies = [
  "syslog-tracing",
  "tempfile",
  "tokio",
+ "tower-http",
  "tracing",
  "tracing-appender",
  "tracing-subscriber",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ tracing-subscriber = { version = "0.3.23", features = [
     "chrono"
 ] }
 axum = { version = "0.8.8", features = ["macros"] }
+tower-http = { version = "0.6", features = ["cors"] }
 config = { version = "0.15.22", features = ["yaml"] }
 base64 = "0.22.1"
 home = "0.5.12"

--- a/doc/manual/en/22-llama-cpp.md
+++ b/doc/manual/en/22-llama-cpp.md
@@ -105,3 +105,10 @@ pgmoneta-mcp-server -c pgmoneta-mcp.conf -u pgmoneta-mcp-users.conf
 ```
 
 Open your MCP client and ask a question about your backups to verify end-to-end setup.
+
+
+### Using llama.cpp Web UI
+
+
+1. Use the URL of the llama server `http://localhost:8080` in your browser. If the page is already open, refresh it.
+2. Open the Web UI settings, select `MCP`, click `Add New Server`, and enter the pgmoneta-mcp URL. If a pgmoneta-mcp server entry exists, delete it and add it again.

--- a/src/bin/server/server.rs
+++ b/src/bin/server/server.rs
@@ -20,6 +20,8 @@ use pgmoneta_mcp::logging::Logger;
 use rmcp::transport::streamable_http_server::{
     StreamableHttpService, session::local::LocalSessionManager,
 };
+use std::time::Duration;
+use tower_http::cors::{Any, CorsLayer};
 
 const BIND_ADDRESS: &str = "0.0.0.0";
 
@@ -67,7 +69,16 @@ async fn main() -> anyhow::Result<()> {
         Default::default(),
     );
 
-    let router = axum::Router::new().nest_service("/mcp", handler);
+    let cors = CorsLayer::new()
+        .allow_origin(Any)
+        .allow_methods(Any)
+        .allow_headers(Any)
+        .expose_headers(Any)
+        .max_age(Duration::from_secs(86400));
+
+    let router = axum::Router::new()
+        .nest_service("/mcp", handler)
+        .layer(cors);
     let tcp_listener = tokio::net::TcpListener::bind(&address).await?;
 
     configuration::CONFIG


### PR DESCRIPTION
The issue comes from the browser’s security system called the `Same Origin Policy`, which sends an OPTIONS request before the real request and blocks it if the server doesn’t explicitly allow it.

`CORS` is a server layer that responds to the browser’s OPTIONS request and tells it what is allowed, so the browser can send the real request.

Closes #98
