### PR TITLE
[#130] tools: add support for annotate command add, update and remove actions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1758,6 +1758,7 @@ dependencies = [
  "serde",
  "serde_ini",
  "serde_json",
+ "serial_test",
  "sha2",
  "syslog-tracing",
  "tempfile",
@@ -2564,6 +2565,31 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serial_test"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "699f4197115b8a7e7ff19c9a315a4bd6fffec26cc4626ef45ecaea389e081c6d"
+dependencies = [
+ "futures-executor",
+ "futures-util",
+ "log",
+ "once_cell",
+ "parking_lot",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94e153fc76e1c6a068703d6d29c508a0b15c061c4b7e43da59cc097bc342673c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,6 +75,7 @@ prometheus-client = "0.24.0"
 inquire = "0.9.4"
 treelog = { version = "0.0.6", features = ["arbitrary-json"] }
 rustyline = "17.0.1"
+serial_test = "3.5.0"
 [target.'cfg(windows)'.dependencies]
 winlog2 = "0.3.2"
 log = "0.4.29"

--- a/doc/manual/en/74-mcp-client.md
+++ b/doc/manual/en/74-mcp-client.md
@@ -207,5 +207,9 @@ admin@localhost:8000/mcp$ List backups on primary server
 admin@localhost:8000/mcp$ metric {"name":"pgmoneta_version"}
 admin@localhost:8000/mcp$ /developer
 admin@localhost:8000/mcp$ list_backups {"server":"primary"}
+admin@localhost:8000/mcp$ annotate_backup {"server":"primary","backup_id":"newest","action":"add","key":"mykey","comment":"mycomment"}
+admin@localhost:8000/mcp$ annotate_backup {"server":"primary","backup_id":"newest","action":"update","key":"mykey","comment":"mynewcomment"}
+admin@localhost:8000/mcp$ annotate_backup {"server":"primary","backup_id":"newest","action":"remove","key":"mykey"}
+admin@localhost:8000/mcp$ get_backup_info {"server":"primary","backup_id":"newest"}
 admin@localhost:8000/mcp# metric {"name":"pgmoneta_retention_server","attributes":{"server":"primary"}}
 ```

--- a/doc/manual/en/79-mcp-api.md
+++ b/doc/manual/en/79-mcp-api.md
@@ -158,6 +158,67 @@ Create an incremental backup:
 }
 ```
 
+#### annotate_backup
+
+**Description**: Adds, updates, or removes a comment annotation on a backup.
+
+**Parameters**:
+- `username` (string, required): pgmoneta admin username
+- `server` (string, required): Server name as configured in pgmoneta
+- `backup_id` (string, required): Backup identifier (can be backup label, "newest", "latest", or "oldest")
+- `action` (string, required): Annotation action. Supported values: `add`, `update`, `remove`
+- `key` (string, required): Annotation key
+- `comment` (string, required for `add` and `update` actions, not required for `remove` action): Annotation text
+
+**Examples**:
+
+Add a comment:
+
+```json
+{
+  "tool": "annotate_backup",
+  "arguments": {
+    "username": "admin",
+    "server": "primary",
+    "backup_id": "latest",
+    "action": "add",
+    "key": "mykey",
+    "comment": "mycomment"
+  }
+}
+```
+
+Update a comment:
+
+```json
+{
+  "tool": "annotate_backup",
+  "arguments": {
+    "username": "admin",
+    "server": "primary",
+    "backup_id": "latest",
+    "action": "update",
+    "key": "mykey",
+    "comment": "mynewcomment"
+  }
+}
+```
+
+Remove a comment:
+
+```json
+{
+  "tool": "annotate_backup",
+  "arguments": {
+    "username": "admin",
+    "server": "primary",
+    "backup_id": "latest",
+    "action": "remove",
+    "key": "mykey"
+  }
+}
+```
+
 #### get_backup_info
 
 **Description**: Retrieves detailed information about a specific backup.

--- a/src/client.rs
+++ b/src/client.rs
@@ -13,6 +13,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
+mod annotate;
 mod backup;
 mod clear;
 mod compression;

--- a/src/client/annotate.rs
+++ b/src/client/annotate.rs
@@ -1,0 +1,52 @@
+// Copyright (C) 2026 The pgmoneta community
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+use super::PgmonetaClient;
+use crate::constant::Command;
+use serde::Serialize;
+
+#[derive(Serialize, Clone, Debug)]
+struct AnnotateRequest {
+    #[serde(rename = "Server")]
+    server: String,
+    #[serde(rename = "Backup")]
+    backup: String,
+    #[serde(rename = "Action")]
+    action: String,
+    #[serde(rename = "Key")]
+    key: String,
+    #[serde(rename = "Comment", skip_serializing_if = "Option::is_none")]
+    comment: Option<String>,
+}
+
+impl PgmonetaClient {
+    pub async fn request_annotate(
+        username: &str,
+        server: &str,
+        backup: &str,
+        action: &str,
+        key: &str,
+        comment: Option<&str>,
+    ) -> anyhow::Result<String> {
+        let request = AnnotateRequest {
+            server: server.to_string(),
+            backup: backup.to_string(),
+            action: action.to_string(),
+            key: key.to_string(),
+            comment: comment.map(|value| value.to_string()),
+        };
+        Self::forward_request(username, Command::ANNOTATE, request).await
+    }
+}

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -13,6 +13,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
+pub mod annotate;
 pub mod backup;
 pub mod clear;
 pub mod compression;
@@ -52,6 +53,7 @@ impl PgmonetaHandler {
     /// Builds the tool router by registering each tool via the trait-based API.
     pub fn tool_router() -> ToolRouter<Self> {
         ToolRouter::new()
+            .with_async_tool::<annotate::AnnotateBackupTool>()
             .with_async_tool::<backup::BackupServerTool>()
             .with_async_tool::<clear::ClearTool>()
             .with_async_tool::<info::GetBackupInfoTool>()

--- a/src/handler/annotate.rs
+++ b/src/handler/annotate.rs
@@ -1,0 +1,177 @@
+// Copyright (C) 2026 The pgmoneta community
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+use std::borrow::Cow;
+use std::sync::Arc;
+
+use super::PgmonetaHandler;
+use crate::client::PgmonetaClient;
+use rmcp::ErrorData as McpError;
+use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
+use rmcp::model::JsonObject;
+use rmcp::schemars;
+
+#[derive(Debug, Default, serde::Deserialize, schemars::JsonSchema)]
+pub struct AnnotateRequest {
+    pub username: String,
+    pub server: String,
+    pub backup_id: String,
+    pub action: String,
+    pub key: String,
+    pub comment: Option<String>,
+}
+
+/// Tool for adding or updating backup annotations.
+pub struct AnnotateBackupTool;
+
+impl ToolBase for AnnotateBackupTool {
+    type Parameter = AnnotateRequest;
+    type Output = String;
+    type Error = McpError;
+
+    fn name() -> Cow<'static, str> {
+        "annotate_backup".into()
+    }
+
+    fn description() -> Option<Cow<'static, str>> {
+        Some(
+            "Annotate a backup using an action and key. \
+            Supported actions are add, remove and update. \
+            The add and update actions require a comment. \
+            The remove action does not require a comment. \
+            \"newest\", \"latest\" or \"oldest\" are also accepted as backup identifier. \
+            The username has to be one of the pgmoneta admins to be able to access pgmoneta."
+                .into(),
+        )
+    }
+
+    fn output_schema() -> Option<Arc<JsonObject>> {
+        None
+    }
+}
+
+impl AsyncTool<PgmonetaHandler> for AnnotateBackupTool {
+    async fn invoke(
+        _service: &PgmonetaHandler,
+        request: AnnotateRequest,
+    ) -> Result<String, McpError> {
+        let action = normalize_action(&request.action)?;
+
+        let comment = match action.as_str() {
+            "add" | "update" => {
+                let value = request.comment.as_deref().unwrap_or("").trim();
+                if value.is_empty() {
+                    return Err(McpError::invalid_params(
+                        format!("The '{}' action requires a non-empty comment", action),
+                        None,
+                    ));
+                }
+                Some(value)
+            }
+            "remove" => None,
+            _ => None,
+        };
+
+        let result: String = PgmonetaClient::request_annotate(
+            &request.username,
+            &request.server,
+            &request.backup_id,
+            &action,
+            &request.key,
+            comment,
+        )
+        .await
+        .map_err(|e| {
+            McpError::internal_error(format!("Failed to annotate backup: {:?}", e), None)
+        })?;
+
+        PgmonetaHandler::generate_call_tool_result_string(&result)
+    }
+}
+
+fn normalize_action(action: &str) -> Result<String, McpError> {
+    let normalized = action.trim().to_ascii_lowercase();
+    match normalized.as_str() {
+        "add" | "update" | "remove" => Ok(normalized),
+        _ => Err(McpError::invalid_params(
+            format!(
+                "Unsupported annotate action '{}'. Supported actions: add, remove, update",
+                action
+            ),
+            None,
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::handler::PgmonetaHandler;
+    use rmcp::handler::server::router::tool::ToolBase;
+    use serde_json::{Map, Value};
+
+    #[test]
+    fn test_annotate_backup_tool_metadata() {
+        assert_eq!(AnnotateBackupTool::name(), "annotate_backup");
+        assert!(AnnotateBackupTool::description().is_some());
+        assert!(
+            AnnotateBackupTool::description()
+                .unwrap()
+                .to_ascii_lowercase()
+                .contains("annotate")
+        );
+    }
+
+    #[test]
+    fn test_handler_has_annotate_tool() {
+        let tools = PgmonetaHandler::tool_router().list_all();
+        let tool_names: Vec<&str> = tools.iter().map(|t| t.name.as_ref()).collect();
+        assert!(
+            tool_names.contains(&"annotate_backup"),
+            "annotate_backup tool should be registered, found: {:?}",
+            tool_names
+        );
+    }
+
+    #[test]
+    fn test_normalize_action() {
+        assert_eq!(normalize_action(" add ").unwrap(), "add");
+        assert_eq!(normalize_action("UPDATE").unwrap(), "update");
+        assert_eq!(normalize_action("Remove").unwrap(), "remove");
+        assert!(normalize_action("replace").is_err());
+    }
+
+    #[test]
+    fn test_generate_call_tool_result_string_annotate() {
+        let response = r#"{"Outcome": {"Status": true, "Command": 20}}"#;
+        let result = PgmonetaHandler::generate_call_tool_result_string(response);
+        assert!(result.is_ok());
+        let output = result.unwrap();
+        let parsed: Map<String, Value> = serde_json::from_str(&output).unwrap();
+        let outcome = parsed["Outcome"].as_object().unwrap();
+        assert_eq!(outcome["Command"], "annotate");
+    }
+
+    #[test]
+    fn test_annotate_response_with_error() {
+        let response = r#"{"Outcome": {"Status": false, "Command": 20, "Error": 2506}}"#;
+        let result = PgmonetaHandler::generate_call_tool_result_string(response);
+        assert!(result.is_ok());
+        let output = result.unwrap();
+        let parsed: Map<String, Value> = serde_json::from_str(&output).unwrap();
+        let outcome = parsed["Outcome"].as_object().unwrap();
+        assert_eq!(outcome["Error"], "Annotate: unknown action");
+    }
+}

--- a/tests/annotate_test.rs
+++ b/tests/annotate_test.rs
@@ -1,0 +1,220 @@
+// Copyright (C) 2026 The pgmoneta community
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+use pgmoneta_mcp::handler::PgmonetaHandler;
+use pgmoneta_mcp::handler::annotate::{AnnotateBackupTool, AnnotateRequest};
+use pgmoneta_mcp::handler::info::{GetBackupInfoTool, InfoRequest as GetBackupInfoRequest};
+use rmcp::handler::server::router::tool::AsyncTool;
+use serde_json::Value;
+use serial_test::serial;
+
+mod common;
+
+async fn clean_annotations(key: &str) {
+    let handler = PgmonetaHandler::new();
+    let request = AnnotateRequest {
+        username: "backup_user".to_string(),
+        server: "primary".to_string(),
+        backup_id: "newest".to_string(),
+        action: "remove".to_string(),
+        key: key.to_string(),
+        comment: None,
+    };
+
+    AnnotateBackupTool::invoke(&handler, request)
+        .await
+        .expect("annotation clean up should succeed");
+}
+
+fn assert_success_annotate_response(response: &str) {
+    let json: Value = serde_json::from_str(response).expect("response should be valid json");
+
+    let header = json
+        .get("Header")
+        .unwrap_or_else(|| panic!("Header field missing in response: {response}"));
+    let command = header
+        .get("Command")
+        .unwrap_or_else(|| panic!("Command field missing in Header: {response}"));
+    assert_eq!(
+        command, "annotate",
+        "unexpected command in response: {response}"
+    );
+
+    let outcome = json
+        .get("Outcome")
+        .unwrap_or_else(|| panic!("Outcome field missing in response: {response}"));
+    let status = outcome
+        .get("Status")
+        .unwrap_or_else(|| panic!("Status field missing in Outcome: {response}"));
+    assert_eq!(status, true, "unexpected status in response: {response}");
+}
+
+#[tokio::test]
+#[serial]
+#[ignore = "requires pgmoneta stack (see test/check.sh and full-test CI job)"]
+async fn annotate_add_comment_test() {
+    common::init_config();
+    let _guard = common::backup_fixture_lock().await;
+    common::ensure_backup("primary")
+        .await
+        .expect("backup fixture should be created");
+
+    let handler = PgmonetaHandler::new();
+    let request = AnnotateRequest {
+        username: "backup_user".to_string(),
+        server: "primary".to_string(),
+        backup_id: "newest".to_string(),
+        action: "add".to_string(),
+        key: "mcp-test-key-add".to_string(),
+        comment: Some("initial comment".to_string()),
+    };
+
+    let response = AnnotateBackupTool::invoke(&handler, request)
+        .await
+        .expect("annotate add should succeed");
+    assert_success_annotate_response(&response);
+
+    let info_request = GetBackupInfoRequest {
+        username: "backup_user".to_string(),
+        server: "primary".to_string(),
+        backup_id: "newest".to_string(),
+    };
+    let info_response = GetBackupInfoTool::invoke(&handler, info_request)
+        .await
+        .expect("get backup info should succeed");
+    let info_json: Value = serde_json::from_str(&info_response)
+        .expect("get backup info response should be valid json");
+    let comments = info_json
+        .get("Response")
+        .and_then(|response| response.get("Comments"))
+        .unwrap_or_else(|| panic!("Comments field missing in info response: {info_response}"));
+    assert_eq!(comments.to_string(), "\"mcp-test-key-add|initial comment\"");
+
+    // clean up
+    clean_annotations("mcp-test-key-add").await;
+}
+
+#[tokio::test]
+#[serial]
+#[ignore = "requires pgmoneta stack (see test/check.sh and full-test CI job)"]
+async fn annotate_update_comment_test() {
+    common::init_config();
+    let _guard = common::backup_fixture_lock().await;
+    common::ensure_backup("primary")
+        .await
+        .expect("backup fixture should be created");
+
+    let handler = PgmonetaHandler::new();
+    let add_request = AnnotateRequest {
+        username: "backup_user".to_string(),
+        server: "primary".to_string(),
+        backup_id: "newest".to_string(),
+        action: "add".to_string(),
+        key: "mcp-test-key-add".to_string(),
+        comment: Some("old comment".to_string()),
+    };
+
+    let _response = AnnotateBackupTool::invoke(&handler, add_request)
+        .await
+        .expect("annotate add before update should succeed");
+
+    let update_request = AnnotateRequest {
+        username: "backup_user".to_string(),
+        server: "primary".to_string(),
+        backup_id: "newest".to_string(),
+        action: "update".to_string(),
+        key: "mcp-test-key-add".to_string(),
+        comment: Some("new comment".to_string()),
+    };
+
+    let response = AnnotateBackupTool::invoke(&handler, update_request)
+        .await
+        .expect("annotate update should succeed");
+    assert_success_annotate_response(&response);
+
+    let info_request = GetBackupInfoRequest {
+        username: "backup_user".to_string(),
+        server: "primary".to_string(),
+        backup_id: "newest".to_string(),
+    };
+    let info_response = GetBackupInfoTool::invoke(&handler, info_request)
+        .await
+        .expect("get backup info should succeed");
+    let info_json: Value = serde_json::from_str(&info_response)
+        .expect("get backup info response should be valid json");
+    let comments = info_json
+        .get("Response")
+        .and_then(|response| response.get("Comments"))
+        .unwrap_or_else(|| panic!("Comments field missing in info response: {info_response}"));
+    assert_eq!(comments.to_string(), "\"mcp-test-key-add|new comment\"");
+
+    // clean up
+    clean_annotations("mcp-test-key-add").await;
+}
+
+#[tokio::test]
+#[serial]
+#[ignore = "requires pgmoneta stack (see test/check.sh and full-test CI job)"]
+async fn annotate_remove_comment_test() {
+    common::init_config();
+    let _guard = common::backup_fixture_lock().await;
+    common::ensure_backup("primary")
+        .await
+        .expect("backup fixture should be created");
+
+    let handler = PgmonetaHandler::new();
+    let add_request = AnnotateRequest {
+        username: "backup_user".to_string(),
+        server: "primary".to_string(),
+        backup_id: "newest".to_string(),
+        action: "add".to_string(),
+        key: "mcp".to_string(),
+        comment: Some("first_comment".to_string()),
+    };
+
+    let _response = AnnotateBackupTool::invoke(&handler, add_request)
+        .await
+        .expect("annotate add before update should succeed");
+
+    let remove_request = AnnotateRequest {
+        username: "backup_user".to_string(),
+        server: "primary".to_string(),
+        backup_id: "newest".to_string(),
+        action: "remove".to_string(),
+        key: "mcp".to_string(),
+        comment: None,
+    };
+
+    let response = AnnotateBackupTool::invoke(&handler, remove_request)
+        .await
+        .expect("annotate remove should succeed");
+    assert_success_annotate_response(&response);
+
+    let info_request = GetBackupInfoRequest {
+        username: "backup_user".to_string(),
+        server: "primary".to_string(),
+        backup_id: "newest".to_string(),
+    };
+    let info_response = GetBackupInfoTool::invoke(&handler, info_request)
+        .await
+        .expect("get backup info should succeed");
+    let info_json: Value = serde_json::from_str(&info_response)
+        .expect("get backup info response should be valid json");
+    let comments = info_json
+        .get("Response")
+        .and_then(|response| response.get("Comments"))
+        .unwrap_or_else(|| panic!("Comments field missing in info response: {info_response}"));
+    assert_eq!(comments.to_string(), "\"\"");
+}


### PR DESCRIPTION
added support for the `add`, `update` and `remove` actions.